### PR TITLE
fix pixel representation for decoding options

### DIFF
--- a/packages/dicom-codec/src/codecs/bigEndian.js
+++ b/packages/dicom-codec/src/codecs/bigEndian.js
@@ -20,21 +20,15 @@ async function decode(imageFrame, imageInfo) {
     codecWrapper.decoderName,
     (context) => {
       context.timer.init("To decode length: " + imageFrame.length);
-      const _imageFrame = getPixelData(imageFrame, imageInfo);
-
       context.timer.end();
-
-      context.logger.log("Decoded length:" + _imageFrame.length);
-      context.logger.log(
-        "Decoded is a Typed array of: " + _imageFrame.constructor.name
-      );
+      context.logger.log("Use getPixel");
 
       const processInfo = {
         duration: context.timer.getDuration(),
       };
 
       return {
-        imageFrame: _imageFrame,
+        imageFrame,
         imageInfo: codecFactory.getTargetImageInfo(imageInfo, imageInfo),
         processInfo,
       };

--- a/packages/dicom-codec/src/codecs/index.js
+++ b/packages/dicom-codec/src/codecs/index.js
@@ -78,9 +78,10 @@ function getCodec(transferSyntaxUID) {
  * @returns {ExtendedImageInfo} Adapted imageInfo to all codecs.
  */
 function adaptImageInfo(imageInfo) {
-  const { rows, columns, bitsAllocated, signed, samplesPerPixel } = imageInfo;
+  const { rows, columns, bitsAllocated, signed, samplesPerPixel, pixelRepresentation } = imageInfo;
 
   return {
+    pixelRepresentation,
     bitsAllocated,
     samplesPerPixel,
     rows, // Number with the image rows/height

--- a/packages/dicom-codec/src/codecs/littleEndian.js
+++ b/packages/dicom-codec/src/codecs/littleEndian.js
@@ -26,21 +26,16 @@ async function decode(imageFrame, imageInfo) {
     codecWrapper.decoderName,
     (context) => {
       context.timer.init("To decode length: " + imageFrame.length);
-      const _imageFrame = getPixelData(imageFrame, imageInfo);
-
       context.timer.end();
 
-      context.logger.log("Decoded length:" + _imageFrame.length);
-      context.logger.log(
-        "Decoded is a Typed array of: " + _imageFrame.constructor.name
-      );
+      context.logger.log("Use getPixel");
 
       const processInfo = {
         duration: context.timer.getDuration(),
       };
 
       return {
-        imageFrame: _imageFrame,
+        imageFrame,
         imageInfo: codecFactory.getTargetImageInfo(imageInfo, imageInfo),
         processInfo,
       };


### PR DESCRIPTION
Includes
- Add pixelRepresentation value to decode mapping options
- Following the standard ensure little/big endian use gitPixelData externally to decode process.