### PR TITLE
fix(tsuid):Use a temporary tsuid for htj2k, not one from DICOM

### DIFF
--- a/packages/dicom-codec/src/codecs/index.js
+++ b/packages/dicom-codec/src/codecs/index.js
@@ -37,7 +37,8 @@ const codecsMap = {
   "1.2.840.10008.1.2.4.81": jpeglsCodec,
   "1.2.840.10008.1.2.4.90": jpeg2000Codec,
   "1.2.840.10008.1.2.4.91": jpeg2000Codec,
-  "1.2.840.10008.1.2.4.96": htj2kCodec,
+  // TODO - update to final ID when released by WG-06
+  "3.2.840.10008.1.2.4.96": htj2kCodec,
   "1.2.840.10008.1.2.5": rleLosslessCodec,
 };
 


### PR DESCRIPTION
It isnt' a good idea to use a TSUID from the IHE DICOM prefix, as that may get used for something else.  Instead, use something related to it, but that is clearly not a standard TSUID, in this case change the 1. prefix to 3.  Will probably be reverted when HTJ2K is released by the DICOM committee, but for now this is better.