### PR TITLE
fix(openjph): HTJ2K encoding was missing a variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,4 +103,7 @@ dist
 
 # TernJS port file
 .tern-port
+
+# IDE packages
 .idea
+*.code-workspace

--- a/packages/dicom-codec/package.json
+++ b/packages/dicom-codec/package.json
@@ -26,7 +26,7 @@
     "@cornerstonejs/codec-big-endian": ">=0.1.0",
     "@cornerstonejs/codec-charls": ">=1.2.3",
     "@cornerstonejs/codec-libjpeg-turbo-8bit": ">=1.2.2",
-    "@cornerstonejs/codec-little-endian": ">=1.2.2",
+    "@cornerstonejs/codec-little-endian": ">=0.0.6",
     "@cornerstonejs/codec-openjpeg": ">=1.2.2",
     "@cornerstonejs/codec-openjph": ">=2.4.3",
     "browser-or-node": "^2.0.0",

--- a/packages/dicom-codec/package.json
+++ b/packages/dicom-codec/package.json
@@ -23,12 +23,12 @@
     "webpack-merge": "^5.7.3"
   },
   "dependencies": {
-    "@cornerstonejs/codec-big-endian": "^0.1.0",
-    "@cornerstonejs/codec-charls": "^1.2.3",
-    "@cornerstonejs/codec-libjpeg-turbo-8bit": "^1.2.2",
-    "@cornerstonejs/codec-little-endian": "^0.0.6",
-    "@cornerstonejs/codec-openjpeg": "^1.2.2",
-    "@cornerstonejs/codec-openjph": "^2.4.3",
+    "@cornerstonejs/codec-big-endian": ">=0.1.0",
+    "@cornerstonejs/codec-charls": ">=1.2.3",
+    "@cornerstonejs/codec-libjpeg-turbo-8bit": ">=1.2.2",
+    "@cornerstonejs/codec-little-endian": ">=1.2.2",
+    "@cornerstonejs/codec-openjpeg": ">=1.2.2",
+    "@cornerstonejs/codec-openjph": ">=2.4.3",
     "browser-or-node": "^2.0.0",
     "jpeg-lossless-decoder-js": "^2.0.4"
   }

--- a/packages/dicom-codec/src/codecs/index.js
+++ b/packages/dicom-codec/src/codecs/index.js
@@ -96,7 +96,8 @@ function adaptImageInfo(imageInfo) {
     componentCount: samplesPerPixel,
     componentsPerPixel: samplesPerPixel,
     signed,
-    isSigned: signed
+    isSigned: signed,
+    isUsingColorTransform: samplesPerPixel>1,
   };
 }
 

--- a/packages/openjphjs/src/HTJ2KDecoder.hpp
+++ b/packages/openjphjs/src/HTJ2KDecoder.hpp
@@ -38,7 +38,7 @@ public:
   {
     // Use the following for debugging to ensure updated version info
     // Update the XX to check that reload has completed
-    // OJPH_INFO(0x00010002, "vXX HTJ2K Encoder");
+    // OJPH_INFO(0x00010002, "vXX HTJ2K Decoder");
   }
 
 #ifdef __EMSCRIPTEN__

--- a/packages/openjphjs/src/HTJ2KEncoder.hpp
+++ b/packages/openjphjs/src/HTJ2KEncoder.hpp
@@ -25,6 +25,12 @@
 class HTJ2KEncoder
 {
 public:
+  HTJ2KEncoder() {
+    // Use the following for debugging to ensure updated version info
+    // Update the XX to check that reload has completed
+    // OJPH_INFO(0x00010002, "vXX HTJ2K Encoder");
+  }
+
 
 #ifdef __EMSCRIPTEN__
   /// <summary>

--- a/packages/openjphjs/test/browser/index.html
+++ b/packages/openjphjs/test/browser/index.html
@@ -438,7 +438,6 @@ var calccrc32 = function(str) {
     }
     $('#precincts').text('' + precints);
     $('#numLayers').text('' + decoder.getNumLayers());
-    $('#colorTransform').text('' + decoder.getIsUsingColorTransform());
 
     $('#progessionOrder').text(['LRCP', 'RLCP', 'RPCL', 'PCRL', 'CPRL'][decoder.getProgressionOrder()]);
     progressionOrder = decoder.getProgressionOrder();
@@ -476,7 +475,6 @@ var calccrc32 = function(str) {
     }
     encoder.setDecompositions(numDecompositionsToEncode);
     encoder.setBlockDimensions({ width: blockDimensions, height: blockDimensions });
-    encoder.setIsUsingColorTransform(decoder.getFrameInfo().componentCount === 3);
     encoder.setProgressionOrder(progressionOrder);
 
     // Do the encode


### PR DESCRIPTION
The HTJ2K encoding was failing because of a variable missing in the javascript declaration for the image type