### PR TITLE
Fix: Update emsdk to get the latest updates

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM emscripten/emsdk:3.1.46
+FROM emscripten/emsdk:3.1.53
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive

--- a/packages/openjpeg/src/CMakeLists.txt
+++ b/packages/openjpeg/src/CMakeLists.txt
@@ -28,7 +28,6 @@ set_target_properties(
       -s DISABLE_EXCEPTION_CATCHING=1 \
       -s ASSERTIONS=0 \
       -s NO_EXIT_RUNTIME=1 \
-      -s MALLOC=dlmalloc \
       -s ALLOW_MEMORY_GROWTH=1 \
       -s INITIAL_MEMORY=50mb \
       -s FILESYSTEM=0 \
@@ -65,7 +64,6 @@ set_target_properties(
          -s DISABLE_EXCEPTION_CATCHING=1 \
          -s ASSERTIONS=0 \
          -s NO_EXIT_RUNTIME=1 \
-         -s MALLOC=dlmalloc \
          -s ALLOW_MEMORY_GROWTH=1 \
 	       -s INITIAL_MEMORY=50mb \
          -s FILESYSTEM=0 \
@@ -104,7 +102,6 @@ set_target_properties(
       -s DISABLE_EXCEPTION_CATCHING=1 \
       -s ASSERTIONS=0 \
       -s NO_EXIT_RUNTIME=1 \
-      -s MALLOC=dlmalloc \
       -s ALLOW_MEMORY_GROWTH=1 \
       -s INITIAL_MEMORY=50mb  \
       -s FILESYSTEM=0 \
@@ -141,7 +138,6 @@ set_target_properties(
          -s DISABLE_EXCEPTION_CATCHING=1 \
          -s ASSERTIONS=0 \
          -s NO_EXIT_RUNTIME=1 \
-         -s MALLOC=dlmalloc \
          -s ALLOW_MEMORY_GROWTH=1 \
 	       -s INITIAL_MEMORY=50mb \
          -s FILESYSTEM=0 \


### PR DESCRIPTION
The issue with emmalloc turned out to be related to issues that were fixed in the latest emsdk version. See the [issue](https://github.com/emscripten-core/emscripten/issues/21277) for more detail.
This PR gets the latest emsdk version (3.1.53) and removes the MALLOC flag from the EMSCRIPTEN build per @chafey's suggestion