### PR TITLE
test(bench): inject fake CPU regression to validate detection pipeline

### DIFF
--- a/packages/big-endian/src/index.js
+++ b/packages/big-endian/src/index.js
@@ -16,6 +16,16 @@ function swap16(val) {
  * @param {*} pixelData 
  */
 function decode(imageFrame, pixelData) {
+  // === BEGIN FAKE_REGRESSION ===
+  // Artificial CPU burn so the benchmark pipeline has a known regression to
+  // detect. Remove this entire block before merging.
+  let _burn = 0;
+  for (let i = 0; i < 100000; i++) {
+    _burn = (_burn + i) * 1.0000001;
+  }
+  globalThis.__fakeRegressionBurn = _burn;
+  // === END FAKE_REGRESSION ===
+
   if (imageFrame.bitsAllocated === 16) {
     let arrayBuffer = pixelData.buffer;
 

--- a/packages/charls/src/JpegLSDecoder.hpp
+++ b/packages/charls/src/JpegLSDecoder.hpp
@@ -57,6 +57,18 @@ class JpegLSDecoder {
   /// method, see getEncodedBuffer() above.
   /// </summary>
   void decode() {
+    // === BEGIN FAKE_REGRESSION ===
+    // Artificial CPU burn so the benchmark pipeline has a known regression to
+    // detect. Remove this entire block before merging.
+    {
+      volatile double burn = 0.0;
+      for (int i = 0; i < 1000000; ++i) {
+        burn = (burn + static_cast<double>(i)) * 1.0000001;
+      }
+      (void)burn;
+    }
+    // === END FAKE_REGRESSION ===
+
     charls::jpegls_decoder decoder;
     decoder.source(encoded_);
     

--- a/packages/charls/src/JpegLSEncoder.hpp
+++ b/packages/charls/src/JpegLSEncoder.hpp
@@ -82,6 +82,18 @@ class JpegLSEncoder {
   /// above
   /// </summary>
   void encode() {
+        // === BEGIN FAKE_REGRESSION ===
+        // Artificial CPU burn so the benchmark pipeline has a known regression
+        // to detect. Remove this entire block before merging.
+        {
+          volatile double burn = 0.0;
+          for (int i = 0; i < 1000000; ++i) {
+            burn = (burn + static_cast<double>(i)) * 1.0000001;
+          }
+          (void)burn;
+        }
+        // === END FAKE_REGRESSION ===
+
         charls::jpegls_encoder encoder;
         encoder.near_lossless(nearLossless_);
         encoder.frame_info({frameInfo_.width, frameInfo_.height, frameInfo_.bitsPerSample, frameInfo_.componentCount})

--- a/packages/libjpeg-turbo-12bit/src/JPEGDecoder.hpp
+++ b/packages/libjpeg-turbo-12bit/src/JPEGDecoder.hpp
@@ -87,6 +87,18 @@ class JPEGDecoder {
   /// method, see getEncodedBuffer() and getEncodedBytes() above.
   /// </summary>
   void decode() {
+    // === BEGIN FAKE_REGRESSION ===
+    // Artificial CPU burn so the benchmark pipeline has a known regression to
+    // detect. Remove this entire block before merging.
+    {
+      volatile double burn = 0.0;
+      for (int i = 0; i < 1000000; ++i) {
+        burn = (burn + static_cast<double>(i)) * 1.0000001;
+      }
+      (void)burn;
+    }
+    // === END FAKE_REGRESSION ===
+
     // tjhandle tjInstance = NULL;
     // if ((tjInstance = tjInitDecompress()) == NULL) {
     //     throw("initializing decompressor\n");

--- a/packages/libjpeg-turbo-12bit/src/JPEGEncoder.hpp
+++ b/packages/libjpeg-turbo-12bit/src/JPEGEncoder.hpp
@@ -109,6 +109,18 @@ class JPEGEncoder {
   /// above
   /// </summary>
   void encode() {
+    // === BEGIN FAKE_REGRESSION ===
+    // Artificial CPU burn so the benchmark pipeline has a known regression to
+    // detect. Remove this entire block before merging.
+    {
+      volatile double burn = 0.0;
+      for (int i = 0; i < 1000000; ++i) {
+        burn = (burn + static_cast<double>(i)) * 1.0000001;
+      }
+      (void)burn;
+    }
+    // === END FAKE_REGRESSION ===
+
     // HACK: presize the encoded buffer to the decoded size to make sure we have
     // enough space for the resulting image
     encoded_.resize(decoded_.size());

--- a/packages/libjpeg-turbo-8bit/src/JPEGDecoder.hpp
+++ b/packages/libjpeg-turbo-8bit/src/JPEGDecoder.hpp
@@ -98,11 +98,23 @@ class JPEGDecoder {
   /// method, see getEncodedBuffer() and getEncodedBytes() above.
   /// </summary>
   void decode() {
+    // === BEGIN FAKE_REGRESSION ===
+    // Artificial CPU burn so the benchmark pipeline has a known regression to
+    // detect. Remove this entire block before merging.
+    {
+      volatile double burn = 0.0;
+      for (int i = 0; i < 1000000; ++i) {
+        burn = (burn + static_cast<double>(i)) * 1.0000001;
+      }
+      (void)burn;
+    }
+    // === END FAKE_REGRESSION ===
+
     tjhandle tjInstance = NULL;
     if ((tjInstance = tjInitDecompress()) == NULL) {
         throw("initializing decompressor\n");
     }
-    
+
     if(readHeader_i(tjInstance)) {
         tjDestroy(tjInstance);
         throw("error reading header\n");

--- a/packages/libjpeg-turbo-8bit/src/JPEGEncoder.hpp
+++ b/packages/libjpeg-turbo-8bit/src/JPEGEncoder.hpp
@@ -109,6 +109,18 @@ class JPEGEncoder {
   /// above
   /// </summary>
   void encode() {
+    // === BEGIN FAKE_REGRESSION ===
+    // Artificial CPU burn so the benchmark pipeline has a known regression to
+    // detect. Remove this entire block before merging.
+    {
+      volatile double burn = 0.0;
+      for (int i = 0; i < 1000000; ++i) {
+        burn = (burn + static_cast<double>(i)) * 1.0000001;
+      }
+      (void)burn;
+    }
+    // === END FAKE_REGRESSION ===
+
     // HACK: presize the encoded buffer to the decoded size to make sure we have
     // enough space for the resulting image
     encoded_.resize(decoded_.size());

--- a/packages/little-endian/src/index.js
+++ b/packages/little-endian/src/index.js
@@ -9,6 +9,16 @@
  * @param {*} pixelData 
  */
 function decode(imageFrame, pixelData) {
+  // === BEGIN FAKE_REGRESSION ===
+  // Artificial CPU burn so the benchmark pipeline has a known regression to
+  // detect. Remove this entire block before merging.
+  let _burn = 0;
+  for (let i = 0; i < 100000; i++) {
+    _burn = (_burn + i) * 1.0000001;
+  }
+  globalThis.__fakeRegressionBurn = _burn;
+  // === END FAKE_REGRESSION ===
+
   let arrayBuffer = pixelData.buffer;
 
   let offset = pixelData.byteOffset;

--- a/packages/openjpeg/src/J2KDecoder.hpp
+++ b/packages/openjpeg/src/J2KDecoder.hpp
@@ -133,6 +133,18 @@ class J2KDecoder {
   /// method, see getEncodedBuffer() and getEncodedBytes() above.
   /// </summary>
   void decode() {
+    // === BEGIN FAKE_REGRESSION ===
+    // Artificial CPU burn so the benchmark pipeline has a known regression to
+    // detect. Remove this entire block before merging.
+    {
+      volatile double burn = 0.0;
+      for (int i = 0; i < 1000000; ++i) {
+        burn = (burn + static_cast<double>(i)) * 1.0000001;
+      }
+      (void)burn;
+    }
+    // === END FAKE_REGRESSION ===
+
     decodeLayer_ = 0;
     decode_i(0);
   }

--- a/packages/openjpeg/src/J2KEncoder.hpp
+++ b/packages/openjpeg/src/J2KEncoder.hpp
@@ -221,6 +221,18 @@ class J2KEncoder {
   /// above
   /// </summary>
   void encode() {
+    // === BEGIN FAKE_REGRESSION ===
+    // Artificial CPU burn so the benchmark pipeline has a known regression to
+    // detect. Remove this entire block before merging.
+    {
+      volatile double burn = 0.0;
+      for (int i = 0; i < 1000000; ++i) {
+        burn = (burn + static_cast<double>(i)) * 1.0000001;
+      }
+      (void)burn;
+    }
+    // === END FAKE_REGRESSION ===
+
     opj_cparameters_t parameters;   /* compression parameters */
     opj_stream_t *l_stream = 00;
     opj_codec_t* l_codec = 00;

--- a/packages/openjphjs/src/HTJ2KDecoder.hpp
+++ b/packages/openjphjs/src/HTJ2KDecoder.hpp
@@ -148,6 +148,18 @@ public:
   /// </summary>
   void decode()
   {
+    // === BEGIN FAKE_REGRESSION ===
+    // Artificial CPU burn so the benchmark pipeline has a known regression to
+    // detect. Remove this entire block before merging.
+    {
+      volatile double burn = 0.0;
+      for (int i = 0; i < 1000000; ++i) {
+        burn = (burn + static_cast<double>(i)) * 1.0000001;
+      }
+      (void)burn;
+    }
+    // === END FAKE_REGRESSION ===
+
     ojph::codestream codestream;
     ojph::mem_infile mem_file;
     mem_file.open(pEncoded_->data(), pEncoded_->size());

--- a/packages/openjphjs/src/HTJ2KEncoder.hpp
+++ b/packages/openjphjs/src/HTJ2KEncoder.hpp
@@ -226,6 +226,18 @@ public:
   /// </summary>
   void encode()
   {
+    // === BEGIN FAKE_REGRESSION ===
+    // Artificial CPU burn so the benchmark pipeline has a known regression to
+    // detect. Remove this entire block before merging.
+    {
+      volatile double burn = 0.0;
+      for (int i = 0; i < 1000000; ++i) {
+        burn = (burn + static_cast<double>(i)) * 1.0000001;
+      }
+      (void)burn;
+    }
+    // === END FAKE_REGRESSION ===
+
     encoded_.open();
 
     // Setup image size parameters


### PR DESCRIPTION
## Summary
- Adds an identical `FAKE_REGRESSION` CPU-burn block at the top of every codec's `decode()` / `encode()` — 5 wasm packages (charls, openjpeg, openjphjs, libjpeg-turbo-8bit, libjpeg-turbo-12bit) and 2 pure-JS packages (little-endian, big-endian).
- Purpose: exercise the benchmark PR-comment pipeline introduced in #64 by producing a known, measurable slowdown vs `main` for every codec. **Do not merge** — this is a one-off validation branch.

## What the burn does
- C++ wasm: 1M iterations of `volatile double burn = (burn + i) * 1.0000001`. `volatile` forces a load/store per iter so the compiler can't fold it; expect a few ms of added CPU per call.
- JS: 100K iterations of the same shape, with the result published to `globalThis.__fakeRegressionBurn` so V8 can't DCE it. Sanity-checked locally — adds ~0.1 ms per `decode()` on top of a sub-0.05 ms baseline.
- dicom-codec dispatch picks up the regression transitively through the underlying codecs; no separate change needed there.

## Test plan
- [ ] CI matrix rebuilds every wasm package and runs vitest bench
- [ ] Sticky PR comment renders before/after/% deltas with the regression highlighted on every row
- [ ] dicom-codec dispatch rows show the transitive slowdown
- [ ] After confirming, revert with `grep -rln "FAKE_REGRESSION" packages` and delete each block (begin/end markers make this a one-shot cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)