### PR TITLE
ci: seed CodSpeed baseline on main pushes and workflow_dispatch

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -11,8 +11,11 @@ name: PR checks
 on:
   pull_request:
   push:
-    branches-ignore:
-      - main
+    # Run on every branch including main so each merge to main seeds a
+    # fresh CodSpeed baseline. Without a main run, PR comments stay stuck
+    # on "Congrats! CodSpeed is installed" with no before/after deltas.
+    branches:
+      - "**"
   # workflow_dispatch lets CodSpeed trigger a backtest run from the
   # dashboard (to seed initial perf data after the repo is connected).
   workflow_dispatch:
@@ -43,11 +46,28 @@ jobs:
           fetch-depth: 0
       - id: list
         name: List changed packages
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
         run: |
           set -e
+          ALL=(charls libjpeg-turbo-8bit libjpeg-turbo-12bit openjpeg openjphjs little-endian big-endian dicom-codec)
+
+          # Baseline runs: on a manual dispatch or any commit landing on
+          # main, build/test/bench every package. The "diff vs main" trick
+          # only makes sense on PR/feature branches — when HEAD === main,
+          # `git diff origin/main..HEAD` is empty and would skip CodSpeed
+          # entirely, leaving the dashboard with no baseline data.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] || [ "$REF" = "refs/heads/main" ]; then
+            json=$(printf '%s\n' "${ALL[@]}" | jq -R . | jq -s -c .)
+            echo "Baseline run ($EVENT_NAME on $REF): forcing all packages"
+            echo "packages=$json" >> "$GITHUB_OUTPUT"
+            echo "any=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           git fetch --no-tags --depth=50 origin main || true
           BASE=$(git merge-base origin/main HEAD || echo "origin/main")
-          ALL=(charls libjpeg-turbo-8bit libjpeg-turbo-12bit openjpeg openjphjs little-endian big-endian dicom-codec)
           changed=()
           for pkg in "${ALL[@]}"; do
             if ! git diff --quiet "$BASE"..HEAD -- "packages/$pkg/"; then


### PR DESCRIPTION
## Summary
- Fixes the chicken-and-egg blocking PR #66's `codspeed-bench` from posting a real regression report: CodSpeed has no baseline data because the workflow was configured to skip main entirely.
- Two changes:
  1. Drop `branches-ignore: main` so every commit landing on main triggers build/test/bench → future merges auto-seed.
  2. In `detect-changes`, treat `workflow_dispatch` or any push to `refs/heads/main` as a "baseline run" that forces the full package list. The existing `git diff origin/main..HEAD` check vacuously returns empty when HEAD is main, which is why my earlier `gh workflow run pr-checks.yml --ref main` finished in 14s and ran nothing.

## Why the existing setup didn't work
`detect-changes` did this on main:

```
No packages changed since 728def44352ac5b5ac293a368c19fc3d7cc73f06.
```

So `any=false` → `build`, `test`, `codspeed-bench` all skipped (each gated on `needs.detect-changes.outputs.any == 'true'`). The CodSpeed dashboard for main therefore stayed empty: `list_runs(branch="main") => {"runs":[]}`.

## After merge
- This PR merging to main will itself trigger the workflow (because `branches-ignore: main` is gone) and produce the first baseline upload.
- Re-running `codspeed-bench` on PR #66 will then post a real before/after table with the fake regression highlighted on every codec.

## Test plan
- [ ] Merge this PR
- [ ] Confirm `pr-checks.yml` runs on main and uploads to CodSpeed
- [ ] Re-run `codspeed-bench` on #66 and verify the sticky comment flips from "Congrats!" to a comparison table

🤖 Generated with [Claude Code](https://claude.com/claude-code)