### PR TITLE
ci(codspeed): move the simulation bench gate to a dedicated self-hosted runner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# Review routing for CI-critical paths. Requires an approval from one of the
+# listed owners when a PR touches a matching path (enforced via branch
+# protection's "require review from Code Owners" on main).
+#
+# Notes on how GitHub evaluates this file:
+#   - gitignore-style patterns; the LAST matching pattern wins.
+#   - Owners must have write access or the rule silently does not bind.
+#   - Any single listed owner's approval satisfies the rule; an author's own
+#     approval never counts, so keep at least two owners per rule.
+#   - Only the copy of this file on the PR's base branch is enforced.
+#
+# No default (catch-all) owner: paths not listed here keep the normal review
+# flow.
+
+/.github/   @jbocce @sedghi @wayfarer3130
+/tools/ci/  @jbocce @sedghi @wayfarer3130

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,18 @@
+# actionlint configuration.
+#
+# actionlint checks `runs-on:` against the labels GitHub provides, so it reports
+# every label it does not ship with as unknown. Those false positives show up in
+# PR review tooling that runs actionlint (e.g. CodeRabbit), so the labels this
+# repo uses are declared here. Keep in sync with `runs-on:` in
+# .github/workflows/.
+
+# Labels on our own self-hosted bench runner. See docs/ci/self-hosted-runner.md.
+#
+# Deliberately NOT listed: codspeed-macro (the walltime job in pr-checks.yml).
+# actionlint reports it as an unknown label too, but it is a CodSpeed-managed
+# machine supplied through their GitHub app — not self-hosted — so it does not
+# belong in this list, and that one diagnostic is left to stand.
+self-hosted-runner:
+  labels:
+    - codspeed-bench
+    - nashua

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -14,9 +14,9 @@ name: Bench
 #           on the job).
 #
 # PRs that modify CI-defining files (workflows, tools/ci/, root manifests) are
-# only benched pre-merge when the author has write access; for other authors
+# only benched pre-merge when they come from a branch in THIS repo; from a fork
 # the bench is deferred until the change is reviewed and merged, and the merge
-# push benches it on main. Package-only PRs are always benched.
+# push benches it on main. Package-only PRs are always benched, fork or not.
 
 on:
   pull_request:
@@ -67,9 +67,16 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          # Relationship of the PR author to this repo, per GitHub
-          # (OWNER / MEMBER / COLLABORATOR / CONTRIBUTOR / ...).
-          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          # Whether the PR branch lives in this repo. If it does, someone with
+          # write access pushed it — a fact, unlike anything derivable from the
+          # author's identity. Do NOT substitute
+          # `github.event.pull_request.author_association`: it does not track
+          # repo access in either direction — its MEMBER value only means
+          # "member of the owning org" (no write implied), and a repo admin here
+          # reports CONTRIBUTOR. There is no reliable alternative from inside a
+          # fork PR's run either: the authoritative collaborator-permission API
+          # needs a token with push access, and fork PRs get a read-only one.
+          IS_SAME_REPO: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           set -euo pipefail
           ALL=(charls libjpeg-turbo-8bit libjpeg-turbo-12bit openjpeg openjphjs little-endian big-endian dicom-codec)
@@ -113,13 +120,8 @@ jobs:
           # every path, so treat the PR as CI-touching (full-sweep / defer).
           if [ "$count" -ge 3000 ]; then ci_touched=true; toolchain_touched=true; fi
 
-          writer=false
-          case "$AUTHOR_ASSOCIATION" in
-            OWNER|MEMBER|COLLABORATOR) writer=true ;;
-          esac
-
-          if [ "$ci_touched" = true ] && [ "$writer" = false ]; then
-            echo "::notice::Bench deferred: this PR changes CI-defining files and the author does not have write access. It will be benched on main once the change is reviewed and merged."
+          if [ "$ci_touched" = true ] && [ "$IS_SAME_REPO" != "true" ]; then
+            echo "::notice::Bench deferred: this PR changes CI-defining files and comes from a fork. It will be benched on main once the change is reviewed and merged."
             echo "proceed=false" >> "$GITHUB_OUTPUT"
             echo "bench=[]" >> "$GITHUB_OUTPUT"
             exit 0
@@ -227,6 +229,12 @@ jobs:
     timeout-minutes: 180
     steps:
       - uses: actions/checkout@v4
+        with:
+          # This runner's workspace persists between jobs, so the default
+          # behaviour of writing the job token into .git/config would leave it on
+          # disk after the job ends. Nothing here needs an authenticated git
+          # remote (CodSpeed reads the commit from the local repo).
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           # EXACT version, not the '22' range every other job uses. For a range,

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -301,9 +301,23 @@ jobs:
         env:
           BENCH: ${{ needs.gate.outputs.bench }}
         run: |
+          set -euo pipefail
           flags=""
           for pkg in $(echo "$BENCH" | jq -r '.[]'); do
-            name=$(node -p "require('./packages/$pkg/package.json').name")
+            # Untrusted: fork PRs control this value (it comes from the PR's own
+            # packages/<pkg>/package.json). Validate against npm's name grammar
+            # before it reaches GITHUB_OUTPUT or any command line. Must be a
+            # whole-string check: keep it in node rather than a line-based tool.
+            name=$(node -e '
+              const pkg = process.argv[1];
+              const { name } = require(`./packages/${pkg}/package.json`);
+              if (typeof name !== "string" ||
+                  !/^(@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/.test(name)) {
+                console.error(`::error::Rejected package name for ${pkg}`);
+                process.exit(1);
+              }
+              process.stdout.write(name);
+            ' "$pkg")
             flags="$flags --scope $name"
           done
           echo "Bench scope flags:$flags"
@@ -353,6 +367,12 @@ jobs:
         # "simulation" to keep that exit-code noise from failing the job
         # (config-level because yarn 1 mangles `--`-forwarded CLI flags).
         uses: CodSpeedHQ/action@4e969336ab9acd4f6f8d025fdd793292b0835df0 # v4.18.2
+        env:
+          # Keep this in env, NOT `${{ }}` in the run: below — an env value is
+          # expanded by the shell after the command line is parsed, so it stays
+          # data. Unquoted below on purpose: the flags must word-split into
+          # repeated `--scope <name>` pairs.
+          SCOPE_FLAGS: ${{ steps.scope.outputs.flags }}
         with:
           mode: simulation
-          run: bash tools/ci/with-nashua-lock.sh yarn lerna run bench --parallel --stream ${{ steps.scope.outputs.flags }}
+          run: bash tools/ci/with-nashua-lock.sh yarn lerna run bench --parallel --stream $SCOPE_FLAGS

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,358 @@
+name: Bench
+
+# CodSpeed simulation bench (the blocking perf regression gate), split out of
+# pr-checks.yml so the workflow that talks to the self-hosted bench runner is
+# small and changes rarely. It reuses the dist artifacts built by the
+# "PR checks" run for the same commit (the `wait` step below), so nothing is
+# compiled twice.
+#
+# Two jobs:
+#   gate  — hosted VM, metadata only (never checks out or executes PR code).
+#           Decides whether the bench should run and what to bench, then waits
+#           for the PR checks build artifacts.
+#   codspeed-bench — the bench itself on the self-hosted box (see the comments
+#           on the job).
+#
+# PRs that modify CI-defining files (workflows, tools/ci/, root manifests) are
+# only benched pre-merge when the author has write access; for other authors
+# the bench is deferred until the change is reviewed and merged, and the merge
+# push benches it on main. Package-only PRs are always benched.
+
+on:
+  pull_request:
+  push:
+    # main only — each merge seeds a fresh CodSpeed baseline. Same reasoning
+    # as pr-checks.yml (see the comment there).
+    branches:
+      - main
+  # Lets CodSpeed trigger a backtest run from the dashboard. The artifact
+  # wait below resolves the dist artifacts from the latest PR checks run for
+  # the same commit (every main commit has one, from its push run).
+  workflow_dispatch:
+
+# Cancel in-flight benches when a new push lands on the same PR / branch.
+# Killing a bench mid-run is safe for the shared-box mutex: flock releases
+# with the process (see tools/ci/with-nashua-lock.sh).
+concurrency:
+  group: bench-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    # Generous because this job WAITS for the PR checks wasm builds to finish
+    # (poll deadline 90 min below) before handing over to the bench.
+    timeout-minutes: 100
+    permissions:
+      contents: read
+      actions: read        # poll the PR checks run / jobs
+      pull-requests: read  # list the PR's changed files
+    outputs:
+      proceed: ${{ steps.decide.outputs.proceed }}
+      bench: ${{ steps.decide.outputs.bench }}
+      ready: ${{ steps.wait.outputs.ready }}
+      run_id: ${{ steps.wait.outputs.run_id }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - id: decide
+        name: Decide bench scope
+        # Metadata only, deliberately no checkout. Computes the bench scope
+        # from the PR's changed-file list (API) the same way detect-changes
+        # in pr-checks.yml does from the git diff — keep the two path lists
+        # in sync. Baseline runs (push to main / dispatch) bench everything.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Relationship of the PR author to this repo, per GitHub
+          # (OWNER / MEMBER / COLLABORATOR / CONTRIBUTOR / ...).
+          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+        run: |
+          set -euo pipefail
+          ALL=(charls libjpeg-turbo-8bit libjpeg-turbo-12bit openjpeg openjphjs little-endian big-endian dicom-codec)
+          ALL_JSON=$(printf '%s\n' "${ALL[@]}" | jq -R . | jq -s -c .)
+
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "Baseline run ($EVENT_NAME): benching all packages"
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            echo "bench=$ALL_JSON" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          files=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" --jq '.[].filename')
+          count=$(wc -l <<<"$files")
+
+          # CI-defining paths: the workflows themselves, the scripts they exec
+          # on the bench runner, and the root manifests that steer install/
+          # bench orchestration there.
+          ci_touched=false
+          # Toolchain paths force a full bench sweep — same list as
+          # detect-changes in pr-checks.yml.
+          toolchain_touched=false
+          changed=()
+          while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            case "$f" in
+              .github/*|tools/ci/*|package.json|yarn.lock|vitest.workspace.mjs|babel.config.json|lerna.json)
+                ci_touched=true ;;
+            esac
+            case "$f" in
+              .github/workflows/*|package.json|yarn.lock|vitest.workspace.mjs|babel.config.json|lerna.json|tools/ci/*|tools/dist-size/*|tools/browser-smoke/*|tools/fixture-verification/*)
+                toolchain_touched=true ;;
+              packages/*)
+                pkg=${f#packages/}; pkg=${pkg%%/*}
+                for known in "${ALL[@]}"; do
+                  [ "$pkg" = "$known" ] && changed+=("$pkg") && break
+                done ;;
+            esac
+          done <<<"$files"
+          # The list endpoint caps at 3000 files; past that we cannot see
+          # every path, so treat the PR as CI-touching (full-sweep / defer).
+          if [ "$count" -ge 3000 ]; then ci_touched=true; toolchain_touched=true; fi
+
+          writer=false
+          case "$AUTHOR_ASSOCIATION" in
+            OWNER|MEMBER|COLLABORATOR) writer=true ;;
+          esac
+
+          if [ "$ci_touched" = true ] && [ "$writer" = false ]; then
+            echo "::notice::Bench deferred: this PR changes CI-defining files and the author does not have write access. It will be benched on main once the change is reviewed and merged."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            echo "bench=[]" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$toolchain_touched" = true ]; then
+            echo "Toolchain change: benching all packages"
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            echo "bench=$ALL_JSON" >> "$GITHUB_OUTPUT"
+          elif [ ${#changed[@]} -gt 0 ]; then
+            bench_json=$(printf '%s\n' "${changed[@]}" | sort -u | jq -R . | jq -s -c .)
+            echo "Benching changed packages: $bench_json"
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            echo "bench=$bench_json" >> "$GITHUB_OUTPUT"
+          else
+            echo "No package changes to bench."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            echo "bench=[]" >> "$GITHUB_OUTPUT"
+          fi
+      - id: wait
+        name: Wait for PR checks build artifacts
+        if: steps.decide.outputs.proceed == 'true'
+        # The dists are built by the "PR checks" run for this same commit
+        # (bench.yml cannot `needs:` across workflow files). Poll that run
+        # until every build job has finished, then hand its run id to the
+        # bench job for the cross-run artifact download.
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          deadline=$((SECONDS + 5400))   # 90 min: wasm builds are the slow part
+          run_id=""
+          ready=false
+          while :; do
+            if [ -z "$run_id" ]; then
+              run_id=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/pr-checks.yml/runs?head_sha=$HEAD_SHA&per_page=1" --jq '.workflow_runs[0].id // empty')
+              [ -n "$run_id" ] && echo "PR checks run: $run_id"
+            fi
+            if [ -n "$run_id" ]; then
+              jobs=$(gh api --paginate "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/jobs?per_page=100" --jq '[.jobs[] | select(.name | startswith("build (")) | {status, conclusion}]' | jq -s -c 'add // []')
+              total=$(jq 'length' <<<"$jobs")
+              completed=$(jq '[.[] | select(.status == "completed")] | length' <<<"$jobs")
+              failed=$(jq '[.[] | select(.status == "completed" and .conclusion != "success")] | length' <<<"$jobs")
+              if [ "$total" -gt 0 ] && [ "$completed" -eq "$total" ]; then
+                if [ "$failed" -gt 0 ]; then
+                  echo "::notice::Bench skipped: $failed build job(s) in the PR checks run did not succeed."
+                else
+                  ready=true
+                fi
+                break
+              fi
+              # A completed run with no build jobs means detect-changes found
+              # nothing to build (e.g. docs-only) — nothing to bench either.
+              status=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id" --jq '.status')
+              if [ "$status" = "completed" ] && [ "$total" -eq 0 ]; then
+                echo "::notice::Bench skipped: the PR checks run built nothing."
+                break
+              fi
+              echo "Waiting on build jobs: $completed/$total completed"
+            else
+              echo "Waiting for the PR checks run to appear for $HEAD_SHA"
+            fi
+            if [ $SECONDS -ge $deadline ]; then
+              echo "::error::Timed out waiting for PR checks build artifacts"
+              exit 1
+            fi
+            sleep 30
+          done
+          echo "ready=$ready" >> "$GITHUB_OUTPUT"
+          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+
+  codspeed-bench:
+    needs: gate
+    if: needs.gate.outputs.proceed == 'true' && needs.gate.outputs.ready == 'true'
+    # Runs on a self-hosted runner dedicated to this repo, on fixed hardware
+    # (label `codspeed-bench`). GitHub's shared runners randomly assign different
+    # physical CPUs (Intel Xeon 8370C vs AMD EPYC 7763); simulation-mode
+    # instruction counts are derived from the runner CPU's cache model, so a
+    # baseline (main) and a PR landing on different CPUs produce spurious
+    # "Different runtime environments detected" deltas. One fixed box keeps
+    # every run on identical hardware, so Simulation is stable run-to-run.
+    # That box ("nashua") is SHARED with the cornerstone3D and OHIF Playwright
+    # runners — three runner processes on one machine, one per repo, each free
+    # to start a job whenever its repo has work. GitHub's `concurrency:` cannot
+    # coordinate across repos, so a filesystem flock mutex
+    # (tools/ci/with-nashua-lock.sh) keeps only one heavy job running at a time;
+    # it wraps the bench command in the "Run CodSpeed benchmarks" step below.
+    # See docs/ci/self-hosted-runner.md for what the box must provide: CodSpeed's
+    # own patched valgrind (NOT the distro valgrind package), libc6-dbg, flock and
+    # a fixed CPU model — node and yarn are provisioned per-job below. That doc
+    # also covers how the shared mutex works and the cutover steps.
+    # IMPORTANT: moving the bench between workflow files (or runners) is a
+    # baseline re-seed event: one main run must complete here before PR
+    # comparisons are meaningful again.
+    runs-on: [self-hosted, codspeed-bench, nashua]
+    permissions:
+      contents: read
+      actions: read         # cross-run artifact download from the PR checks run
+      pull-requests: write  # CodSpeed action posts a sticky PR comment
+      id-token: write       # OIDC token used by CodSpeedHQ/action for auth
+    # Bounded because the bench command can queue behind a cornerstone3D or
+    # OHIF Playwright run on the shared box: up to NASHUA_LOCK_WAIT (90 min) of
+    # waiting plus the valgrind fan-out itself. Well under GitHub's 360 min
+    # default, so a wedged lock surfaces in hours rather than most of a day.
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          # EXACT version, not the '22' range every other job uses. For a range,
+          # setup-node takes any satisfying version already in the runner's tool
+          # cache without checking the network — and on a self-hosted box that
+          # cache persists, so the bench would silently freeze on whichever 22.x
+          # landed there first and jump whenever the box is rebuilt. A V8 patch
+          # bump shifts instruction counts the same way a different CPU does.
+          # 22.23.1 is what the current main baseline was measured on; changing
+          # it is a deliberate re-seed event (see docs/ci/self-hosted-runner.md).
+          node-version: '22.23.1'
+      # nashua has no yarn: setup-node ships node + npm only, GitHub's hosted
+      # images preinstall yarn 1, and the other two repos on this box use pnpm.
+      # Corepack is bundled with node 22 and fetches over Node's own https, so it
+      # works where `npm i -g yarn` is unreliable here — the runner's bundled node
+      # has a corrupted npm ("Cannot find module '../lib/cli.js'"), which is why
+      # OHIF's workflow also went the Corepack route on this box. Pinned to the
+      # same yarn the build job uses rather than Corepack's bundled default, and
+      # activated AFTER setup-node so the shim lands in that node's bin dir.
+      # NOTE: node 25 unbundles corepack — revisit this step before any such bump.
+      - name: Provide yarn 1 via Corepack
+        run: |
+          corepack enable yarn
+          corepack prepare yarn@1.22.22 --activate
+          yarn --version
+      - name: Download all built dists
+        uses: actions/download-artifact@v4
+        with:
+          pattern: dist-*
+          path: tmp/
+          # Cross-run download: the artifacts live on the PR checks run the
+          # gate waited for, not on this run.
+          run-id: ${{ needs.gate.outputs.run_id }}
+          github-token: ${{ github.token }}
+      - name: Replay dists into packages/<pkg>/dist
+        run: |
+          set -e
+          for d in tmp/dist-*; do
+            [ -d "$d" ] || continue
+            pkg=$(basename "$d" | sed 's/^dist-//')
+            mkdir -p "packages/$pkg/dist"
+            shopt -s dotglob nullglob
+            cp -r "$d"/* "packages/$pkg/dist/" 2>/dev/null || true
+          done
+      - name: Restore node_modules cache
+        id: modules-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: modules-node22-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
+      - name: Install dependencies
+        if: steps.modules-cache.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
+      - name: Log CPU info
+        # GitHub standard runners are randomly assigned different physical
+        # CPUs (e.g. Intel Xeon 8370C vs AMD EPYC 7763) with different cache
+        # sizes and ISA extensions; glibc dispatches different code paths on
+        # each, so even simulation-mode instruction counts shift between
+        # them. CodSpeed flags such comparisons as "different runtime
+        # environments". Logging the CPU makes those warnings diagnosable
+        # at a glance (recommendation from
+        # https://codspeed.io/blog/unrelated-benchmark-regression).
+        run: lscpu | grep -E "Model name|Cache|Flags" | head -5 || true
+      - name: Compute bench scope
+        # Translate the changed-package directory names into lerna --scope
+        # flags so PRs only bench what they touched. Baseline runs (main /
+        # workflow_dispatch) get the full list from the gate, which makes
+        # this a no-op filter there.
+        id: scope
+        env:
+          BENCH: ${{ needs.gate.outputs.bench }}
+        run: |
+          flags=""
+          for pkg in $(echo "$BENCH" | jq -r '.[]'); do
+            name=$(node -p "require('./packages/$pkg/package.json').name")
+            flags="$flags --scope $name"
+          done
+          echo "Bench scope flags:$flags"
+          echo "flags=$flags" >> "$GITHUB_OUTPUT"
+      - name: Run CodSpeed benchmarks
+        # CodSpeedHQ/action@v4 sets up CPU simulation (Cachegrind-based
+        # instruction counting on a modeled CPU + cache hierarchy), runs
+        # the inner command under valgrind, uploads to codspeed.io, and
+        # posts/updates a sticky PR comment with the per-bench deltas.
+        # Authenticates via GitHub OIDC (id-token: write above) so no
+        # CODSPEED_TOKEN secret is needed.
+        #
+        # mode: simulation — the blocking regression gate:
+        #   - deterministic: <1% run-to-run drift (verified across 3
+        #     runs of identical source)
+        #   - no metered CI minutes (self-hosted runners are not billed;
+        #     they cost shared time on the nashua box instead, which is
+        #     what the flock mutex below rations)
+        #   - regression-detection signal is strong even though the
+        #     headline numbers are MODELED instruction-time, not real
+        #     wall-clock (JS-loop benches inflate 30-100x vs production
+        #     V8 due to no JIT under Cachegrind; wasm decode kernels
+        #     inflate ~5-15x; pure native ~1x)
+        # The codspeed-walltime job in pr-checks.yml complements this with
+        # real wall-clock measurements on CodSpeed macro runners.
+        # See BENCHMARKING.md at the repo root for the full measurement
+        # model, how to read the cold/warm bench split, and what the
+        # CodSpeed dashboard warnings mean.
+        # Pinned to the commit SHA of v4.18.2 (not the floating @v4, nor the
+        # tag — tags can be moved) so the instrumentation environment stays
+        # byte-identical between the main baseline and PR runs. Bump by
+        # resolving the new tag: gh api repos/CodSpeedHQ/action/git/ref/tags/<tag>
+        # (dereference the annotated tag to its commit).
+        # The inner command is wrapped in tools/ci/with-nashua-lock.sh, the
+        # cross-repo flock mutex for this shared box (see that script's header).
+        # Taking the lock INSIDE the action's `run` — rather than in an earlier
+        # step — is deliberate on both counts: flock lives and dies with a
+        # process, so it cannot be held across separate workflow steps, and this
+        # way only the CPU-saturating bench fan-out is serialized, leaving the
+        # action's own setup and result upload free to overlap with a Playwright
+        # run on one of the other two repos.
+        # Note: vitest 3's hard-coded 60s worker-RPC timer counts real
+        # seconds while valgrind slows the process ~60x, so large suites
+        # structurally trip "Timeout calling onTaskUpdate" AFTER their
+        # benches complete. The vitest configs set
+        # dangerouslyIgnoreUnhandledErrors when CODSPEED_RUNNER_MODE is
+        # "simulation" to keep that exit-code noise from failing the job
+        # (config-level because yarn 1 mangles `--`-forwarded CLI flags).
+        uses: CodSpeedHQ/action@4e969336ab9acd4f6f8d025fdd793292b0835df0 # v4.18.2
+        with:
+          mode: simulation
+          run: bash tools/ci/with-nashua-lock.sh yarn lerna run bench --parallel --stream ${{ steps.scope.outputs.flags }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -332,13 +332,18 @@ jobs:
   codspeed-bench:
     needs: [detect-changes, build]
     if: needs.detect-changes.outputs.any == 'true'
-    # Pin the OS (not ubuntu-latest) so PR runs are measured in the same
-    # runtime environment as the baseline seeded on main. A drifting
-    # ubuntu-latest image changes the valgrind/toolchain fingerprint between
-    # baseline and PR, which makes CodSpeed report "Different runtime
-    # environments detected" and refuse to trust the comparison. The baseline
-    # on main must be re-seeded after changing this so both sides match.
-    runs-on: ubuntu-24.04
+    # Runs on a DEDICATED self-hosted runner with fixed hardware (label
+    # `codspeed-bench`). GitHub's shared runners randomly assign different
+    # physical CPUs (Intel Xeon 8370C vs AMD EPYC 7763); simulation-mode
+    # instruction counts are derived from the runner CPU's cache model, so a
+    # baseline (main) and a PR landing on different CPUs produce spurious
+    # "Different runtime environments detected" deltas. One fixed box keeps
+    # every run on identical hardware, so Simulation is stable run-to-run.
+    # See docs/ci/self-hosted-runner.md for what the box must provide
+    # (valgrind, node 22, a pinned/isolated CPU) and the cutover steps.
+    # IMPORTANT: after this lands, the baseline on main must be re-seeded by
+    # one main run on THIS runner before PR comparisons are meaningful.
+    runs-on: [self-hosted, codspeed-bench]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -464,9 +464,11 @@ jobs:
         # See BENCHMARKING.md at the repo root for the full measurement
         # model, how to read the cold/warm bench split, and what the
         # CodSpeed dashboard warnings mean.
-        # Pinned to a full version (not the floating @v4) so the
-        # instrumentation environment stays identical between the main
-        # baseline and PR runs.
+        # Pinned to the commit SHA of v4.18.2 (not the floating @v4, nor the
+        # tag — tags can be moved) so the instrumentation environment stays
+        # byte-identical between the main baseline and PR runs. Bump by
+        # resolving the new tag: gh api repos/CodSpeedHQ/action/git/ref/tags/<tag>
+        # (dereference the annotated tag to its commit).
         # The inner command is wrapped in tools/ci/with-nashua-lock.sh, the
         # cross-repo flock mutex for this shared box (see that script's header).
         # Taking the lock INSIDE the action's `run` — rather than in an earlier
@@ -482,7 +484,7 @@ jobs:
         # dangerouslyIgnoreUnhandledErrors when CODSPEED_RUNNER_MODE is
         # "simulation" to keep that exit-code noise from failing the job
         # (config-level because yarn 1 mangles `--`-forwarded CLI flags).
-        uses: CodSpeedHQ/action@v4.18.2
+        uses: CodSpeedHQ/action@4e969336ab9acd4f6f8d025fdd793292b0835df0 # v4.18.2
         with:
           mode: simulation
           run: bash tools/ci/with-nashua-lock.sh yarn lerna run bench --parallel --stream ${{ steps.scope.outputs.flags }}
@@ -566,7 +568,7 @@ jobs:
         # processes would contend for cores and add noise — run packages
         # sequentially (--concurrency 1), unlike the simulation job where
         # instruction counting is immune to contention.
-        uses: CodSpeedHQ/action@v4.18.2
+        uses: CodSpeedHQ/action@4e969336ab9acd4f6f8d025fdd793292b0835df0 # v4.18.2
         with:
           mode: walltime
           run: yarn lerna run bench --concurrency 1 --stream ${{ steps.scope.outputs.flags }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -98,10 +98,13 @@ jobs:
           # a vitest upgrade in the root lockfile) must run the full
           # pipeline with a full bench sweep — previously such PRs matched
           # no package path and skipped CI entirely. tools/ entries count
-          # too: browser-smoke drives the browser-smoke job, and the test
-          # suites import reference derivations from
-          # tools/fixture-verification/gen/ — a change to either must not
-          # land with CI skipped.
+          # too: browser-smoke drives the browser-smoke job, the test suites
+          # import reference derivations from tools/fixture-verification/gen/,
+          # and tools/ci/ holds the flock wrapper the bench command actually
+          # execs — a change to any of them must not land with CI skipped.
+          # Note this forces a FULL bench sweep, which on the shared nashua box
+          # holds the mutex for the duration; that is the same trade already
+          # made for .github/workflows/ changes, and both are rare.
           TOOLCHAIN_PATHS=(
             ".github/workflows/"
             "package.json"
@@ -109,6 +112,7 @@ jobs:
             "vitest.workspace.mjs"
             "babel.config.json"
             "lerna.json"
+            "tools/ci/"
             "tools/dist-size/"
             "tools/browser-smoke/"
             "tools/fixture-verification/"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,7 +2,10 @@ name: PR checks
 
 # Pipeline: builds run as a per-package parallel matrix (wasm compiles are
 # the slow part), then a single test job runs the whole vitest workspace
-# against the built dists, and CodSpeed benches the packages the PR touched.
+# against the built dists. The CodSpeed simulation bench lives in bench.yml,
+# which waits for THIS workflow's dist artifacts and benches the packages
+# the PR touched; the advisory walltime bench stays here (codspeed-walltime
+# below).
 #
 # Toolchain bumps (emsdk image tag below, root package.json/yarn.lock, this
 # workflow itself) force the FULL pipeline including a full bench sweep.
@@ -41,10 +44,9 @@ concurrency:
   group: pr-checks-${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+# Job-level permissions where a job needs more (codspeed-walltime).
 permissions:
   contents: read
-  pull-requests: write  # CodSpeed action posts a sticky PR comment
-  id-token: write       # OIDC token used by CodSpeedHQ/action for auth
 
 jobs:
   detect-changes:
@@ -55,9 +57,12 @@ jobs:
     #     missing (no more silently-skipped suites), so any package change
     #     builds the full set. Docs-only changes still skip everything.
     #   bench — only the packages that actually changed. CodSpeed benches
-    #     run under valgrind (the slowest job in the workflow), and a PR
-    #     only needs deltas for what it touched; main re-benches everything
-    #     to keep full baselines.
+    #     run under valgrind (the slowest thing in CI), and a PR only needs
+    #     deltas for what it touched; main re-benches everything to keep
+    #     full baselines. Consumed by codspeed-walltime below; the
+    #     simulation bench in bench.yml computes the same scope from the
+    #     PR's changed-file list — keep TOOLCHAIN_PATHS below in sync with
+    #     the path lists in bench.yml's gate job.
     runs-on: ubuntu-latest
     outputs:
       packages: ${{ steps.list.outputs.packages }}
@@ -333,162 +338,6 @@ jobs:
       - name: Browser smoke decode
         run: node tools/browser-smoke/run.js
 
-  codspeed-bench:
-    needs: [detect-changes, build]
-    if: needs.detect-changes.outputs.any == 'true'
-    # Runs on a self-hosted runner dedicated to this repo, on fixed hardware
-    # (label `codspeed-bench`). GitHub's shared runners randomly assign different
-    # physical CPUs (Intel Xeon 8370C vs AMD EPYC 7763); simulation-mode
-    # instruction counts are derived from the runner CPU's cache model, so a
-    # baseline (main) and a PR landing on different CPUs produce spurious
-    # "Different runtime environments detected" deltas. One fixed box keeps
-    # every run on identical hardware, so Simulation is stable run-to-run.
-    # That box ("nashua") is SHARED with the cornerstone3D and OHIF Playwright
-    # runners — three runner processes on one machine, one per repo, each free
-    # to start a job whenever its repo has work. GitHub's `concurrency:` cannot
-    # coordinate across repos, so a filesystem flock mutex
-    # (tools/ci/with-nashua-lock.sh) keeps only one heavy job running at a time;
-    # it wraps the bench command in the "Run CodSpeed benchmarks" step below.
-    # See docs/ci/self-hosted-runner.md for what the box must provide: CodSpeed's
-    # own patched valgrind (NOT the distro valgrind package), libc6-dbg, flock and
-    # a fixed CPU model — node and yarn are provisioned per-job below. That doc
-    # also covers how the shared mutex works and the cutover steps.
-    # IMPORTANT: after this lands, the baseline on main must be re-seeded by
-    # one main run on THIS runner before PR comparisons are meaningful.
-    runs-on: [self-hosted, codspeed-bench, nashua]
-    # Bounded because the bench command can now queue behind a cornerstone3D or
-    # OHIF Playwright run on the shared box: up to NASHUA_LOCK_WAIT (90 min) of
-    # waiting plus the valgrind fan-out itself. Well under GitHub's 360 min
-    # default, so a wedged lock surfaces in hours rather than most of a day.
-    timeout-minutes: 180
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          # EXACT version, not the '22' range every other job uses. For a range,
-          # setup-node takes any satisfying version already in the runner's tool
-          # cache without checking the network — and on a self-hosted box that
-          # cache persists, so the bench would silently freeze on whichever 22.x
-          # landed there first and jump whenever the box is rebuilt. A V8 patch
-          # bump shifts instruction counts the same way a different CPU does.
-          # 22.23.1 is what the current main baseline was measured on; changing
-          # it is a deliberate re-seed event (see docs/ci/self-hosted-runner.md).
-          node-version: '22.23.1'
-      # nashua has no yarn: setup-node ships node + npm only, GitHub's hosted
-      # images preinstall yarn 1, and the other two repos on this box use pnpm.
-      # Corepack is bundled with node 22 and fetches over Node's own https, so it
-      # works where `npm i -g yarn` is unreliable here — the runner's bundled node
-      # has a corrupted npm ("Cannot find module '../lib/cli.js'"), which is why
-      # OHIF's workflow also went the Corepack route on this box. Pinned to the
-      # same yarn the build job uses rather than Corepack's bundled default, and
-      # activated AFTER setup-node so the shim lands in that node's bin dir.
-      # NOTE: node 25 unbundles corepack — revisit this step before any such bump.
-      - name: Provide yarn 1 via Corepack
-        run: |
-          corepack enable yarn
-          corepack prepare yarn@1.22.22 --activate
-          yarn --version
-      - name: Download all built dists
-        uses: actions/download-artifact@v4
-        with:
-          pattern: dist-*
-          path: tmp/
-      - name: Replay dists into packages/<pkg>/dist
-        run: |
-          set -e
-          for d in tmp/dist-*; do
-            [ -d "$d" ] || continue
-            pkg=$(basename "$d" | sed 's/^dist-//')
-            mkdir -p "packages/$pkg/dist"
-            shopt -s dotglob nullglob
-            cp -r "$d"/* "packages/$pkg/dist/" 2>/dev/null || true
-          done
-      - name: Restore node_modules cache
-        id: modules-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            node_modules
-            packages/*/node_modules
-          key: modules-node22-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
-      - name: Install dependencies
-        if: steps.modules-cache.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile
-      - name: Log CPU info
-        # GitHub standard runners are randomly assigned different physical
-        # CPUs (e.g. Intel Xeon 8370C vs AMD EPYC 7763) with different cache
-        # sizes and ISA extensions; glibc dispatches different code paths on
-        # each, so even simulation-mode instruction counts shift between
-        # them. CodSpeed flags such comparisons as "different runtime
-        # environments". Logging the CPU makes those warnings diagnosable
-        # at a glance (recommendation from
-        # https://codspeed.io/blog/unrelated-benchmark-regression).
-        run: lscpu | grep -E "Model name|Cache|Flags" | head -5 || true
-      - name: Compute bench scope
-        # Translate the changed-package directory names into lerna --scope
-        # flags so PRs only bench what they touched. Baseline runs (main /
-        # workflow_dispatch) get the full list from detect-changes, which
-        # makes this a no-op filter there.
-        id: scope
-        env:
-          BENCH: ${{ needs.detect-changes.outputs.bench }}
-        run: |
-          flags=""
-          for pkg in $(echo "$BENCH" | jq -r '.[]'); do
-            name=$(node -p "require('./packages/$pkg/package.json').name")
-            flags="$flags --scope $name"
-          done
-          echo "Bench scope flags:$flags"
-          echo "flags=$flags" >> "$GITHUB_OUTPUT"
-      - name: Run CodSpeed benchmarks
-        # CodSpeedHQ/action@v4 sets up CPU simulation (Cachegrind-based
-        # instruction counting on a modeled CPU + cache hierarchy), runs
-        # the inner command under valgrind, uploads to codspeed.io, and
-        # posts/updates a sticky PR comment with the per-bench deltas.
-        # Authenticates via GitHub OIDC (id-token: write above) so no
-        # CODSPEED_TOKEN secret is needed.
-        #
-        # mode: simulation — the blocking regression gate:
-        #   - deterministic: <1% run-to-run drift (verified across 3
-        #     runs of identical source)
-        #   - no metered CI minutes (self-hosted runners are not billed;
-        #     they cost shared time on the nashua box instead, which is
-        #     what the flock mutex below rations)
-        #   - regression-detection signal is strong even though the
-        #     headline numbers are MODELED instruction-time, not real
-        #     wall-clock (JS-loop benches inflate 30-100x vs production
-        #     V8 due to no JIT under Cachegrind; wasm decode kernels
-        #     inflate ~5-15x; pure native ~1x)
-        # The codspeed-walltime job below complements this with real
-        # wall-clock measurements on CodSpeed macro runners.
-        # See BENCHMARKING.md at the repo root for the full measurement
-        # model, how to read the cold/warm bench split, and what the
-        # CodSpeed dashboard warnings mean.
-        # Pinned to the commit SHA of v4.18.2 (not the floating @v4, nor the
-        # tag — tags can be moved) so the instrumentation environment stays
-        # byte-identical between the main baseline and PR runs. Bump by
-        # resolving the new tag: gh api repos/CodSpeedHQ/action/git/ref/tags/<tag>
-        # (dereference the annotated tag to its commit).
-        # The inner command is wrapped in tools/ci/with-nashua-lock.sh, the
-        # cross-repo flock mutex for this shared box (see that script's header).
-        # Taking the lock INSIDE the action's `run` — rather than in an earlier
-        # step — is deliberate on both counts: flock lives and dies with a
-        # process, so it cannot be held across separate workflow steps, and this
-        # way only the CPU-saturating bench fan-out is serialized, leaving the
-        # action's own setup and result upload free to overlap with a Playwright
-        # run on one of the other two repos.
-        # Note: vitest 3's hard-coded 60s worker-RPC timer counts real
-        # seconds while valgrind slows the process ~60x, so large suites
-        # structurally trip "Timeout calling onTaskUpdate" AFTER their
-        # benches complete. The vitest configs set
-        # dangerouslyIgnoreUnhandledErrors when CODSPEED_RUNNER_MODE is
-        # "simulation" to keep that exit-code noise from failing the job
-        # (config-level because yarn 1 mangles `--`-forwarded CLI flags).
-        uses: CodSpeedHQ/action@4e969336ab9acd4f6f8d025fdd793292b0835df0 # v4.18.2
-        with:
-          mode: simulation
-          run: bash tools/ci/with-nashua-lock.sh yarn lerna run bench --parallel --stream ${{ steps.scope.outputs.flags }}
-
   codspeed-walltime:
     needs: [detect-changes, build]
     # Gated behind a repository variable: a `runs-on: codspeed-macro` job
@@ -499,13 +348,17 @@ jobs:
     # repositories), then: gh variable set CODSPEED_MACRO_ENABLED --body true
     if: needs.detect-changes.outputs.any == 'true' && vars.CODSPEED_MACRO_ENABLED == 'true'
     # Advisory instrument: real wall-clock numbers (V8 JIT active, real
-    # cache/branch behavior) that complement the simulation gate above —
+    # cache/branch behavior) that complement the simulation gate (bench.yml) —
     # simulation catches small algorithmic slips deterministically,
     # walltime keeps the numbers honest on real hardware and covers the
     # pure-JS packages where the no-JIT simulation model is furthest from
     # production. Failures here must not block the PR while this beds in.
     continue-on-error: true
     timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: write  # CodSpeed action posts a sticky PR comment
+      id-token: write       # OIDC token used by CodSpeedHQ/action for auth
     # CodSpeed-managed 16-core ARM64 bare-metal machine, tuned for
     # low-noise walltime measurement. Requires the CodSpeed GitHub app on
     # an organization account. NOTE: ARM64 — anything cached must be

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -409,9 +409,24 @@ jobs:
         env:
           BENCH: ${{ needs.detect-changes.outputs.bench }}
         run: |
+          set -euo pipefail
           flags=""
           for pkg in $(echo "$BENCH" | jq -r '.[]'); do
-            name=$(node -p "require('./packages/$pkg/package.json').name")
+            # Untrusted: fork PRs control this value (it comes from the PR's own
+            # packages/<pkg>/package.json). Validate against npm's name grammar
+            # before it reaches GITHUB_OUTPUT or any command line. Must be a
+            # whole-string check: keep it in node rather than a line-based tool.
+            # Keep in step with the same check in bench.yml.
+            name=$(node -e '
+              const pkg = process.argv[1];
+              const { name } = require(`./packages/${pkg}/package.json`);
+              if (typeof name !== "string" ||
+                  !/^(@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/.test(name)) {
+                console.error(`::error::Rejected package name for ${pkg}`);
+                process.exit(1);
+              }
+              process.stdout.write(name);
+            ' "$pkg")
             flags="$flags --scope $name"
           done
           echo "Bench scope flags:$flags"
@@ -422,6 +437,12 @@ jobs:
         # sequentially (--concurrency 1), unlike the simulation job where
         # instruction counting is immune to contention.
         uses: CodSpeedHQ/action@4e969336ab9acd4f6f8d025fdd793292b0835df0 # v4.18.2
+        env:
+          # Keep this in env, NOT `${{ }}` in the run: below — an env value is
+          # expanded by the shell after the command line is parsed, so it stays
+          # data. Unquoted below on purpose: the flags must word-split into
+          # repeated `--scope <name>` pairs.
+          SCOPE_FLAGS: ${{ steps.scope.outputs.flags }}
         with:
           mode: walltime
-          run: yarn lerna run bench --concurrency 1 --stream ${{ steps.scope.outputs.flags }}
+          run: yarn lerna run bench --concurrency 1 --stream $SCOPE_FLAGS

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -332,23 +332,58 @@ jobs:
   codspeed-bench:
     needs: [detect-changes, build]
     if: needs.detect-changes.outputs.any == 'true'
-    # Runs on a DEDICATED self-hosted runner with fixed hardware (label
-    # `codspeed-bench`). GitHub's shared runners randomly assign different
+    # Runs on a self-hosted runner dedicated to this repo, on fixed hardware
+    # (label `codspeed-bench`). GitHub's shared runners randomly assign different
     # physical CPUs (Intel Xeon 8370C vs AMD EPYC 7763); simulation-mode
     # instruction counts are derived from the runner CPU's cache model, so a
     # baseline (main) and a PR landing on different CPUs produce spurious
     # "Different runtime environments detected" deltas. One fixed box keeps
     # every run on identical hardware, so Simulation is stable run-to-run.
-    # See docs/ci/self-hosted-runner.md for what the box must provide
-    # (valgrind, node 22, a pinned/isolated CPU) and the cutover steps.
+    # That box ("nashua") is SHARED with the cornerstone3D and OHIF Playwright
+    # runners — three runner processes on one machine, one per repo, each free
+    # to start a job whenever its repo has work. GitHub's `concurrency:` cannot
+    # coordinate across repos, so a filesystem flock mutex
+    # (tools/ci/with-nashua-lock.sh) keeps only one heavy job running at a time;
+    # it wraps the bench command in the "Run CodSpeed benchmarks" step below.
+    # See docs/ci/self-hosted-runner.md for what the box must provide: CodSpeed's
+    # own patched valgrind (NOT the distro valgrind package), libc6-dbg, flock and
+    # a fixed CPU model — node and yarn are provisioned per-job below. That doc
+    # also covers how the shared mutex works and the cutover steps.
     # IMPORTANT: after this lands, the baseline on main must be re-seeded by
     # one main run on THIS runner before PR comparisons are meaningful.
-    runs-on: [self-hosted, codspeed-bench]
+    runs-on: [self-hosted, codspeed-bench, nashua]
+    # Bounded because the bench command can now queue behind a cornerstone3D or
+    # OHIF Playwright run on the shared box: up to NASHUA_LOCK_WAIT (90 min) of
+    # waiting plus the valgrind fan-out itself. Well under GitHub's 360 min
+    # default, so a wedged lock surfaces in hours rather than most of a day.
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          # EXACT version, not the '22' range every other job uses. For a range,
+          # setup-node takes any satisfying version already in the runner's tool
+          # cache without checking the network — and on a self-hosted box that
+          # cache persists, so the bench would silently freeze on whichever 22.x
+          # landed there first and jump whenever the box is rebuilt. A V8 patch
+          # bump shifts instruction counts the same way a different CPU does.
+          # 22.23.1 is what the current main baseline was measured on; changing
+          # it is a deliberate re-seed event (see docs/ci/self-hosted-runner.md).
+          node-version: '22.23.1'
+      # nashua has no yarn: setup-node ships node + npm only, GitHub's hosted
+      # images preinstall yarn 1, and the other two repos on this box use pnpm.
+      # Corepack is bundled with node 22 and fetches over Node's own https, so it
+      # works where `npm i -g yarn` is unreliable here — the runner's bundled node
+      # has a corrupted npm ("Cannot find module '../lib/cli.js'"), which is why
+      # OHIF's workflow also went the Corepack route on this box. Pinned to the
+      # same yarn the build job uses rather than Corepack's bundled default, and
+      # activated AFTER setup-node so the shim lands in that node's bin dir.
+      # NOTE: node 25 unbundles corepack — revisit this step before any such bump.
+      - name: Provide yarn 1 via Corepack
+        run: |
+          corepack enable yarn
+          corepack prepare yarn@1.22.22 --activate
+          yarn --version
       - name: Download all built dists
         uses: actions/download-artifact@v4
         with:
@@ -412,7 +447,9 @@ jobs:
         # mode: simulation — the blocking regression gate:
         #   - deterministic: <1% run-to-run drift (verified across 3
         #     runs of identical source)
-        #   - free CI minutes (runs on GitHub-hosted runners)
+        #   - no metered CI minutes (self-hosted runners are not billed;
+        #     they cost shared time on the nashua box instead, which is
+        #     what the flock mutex below rations)
         #   - regression-detection signal is strong even though the
         #     headline numbers are MODELED instruction-time, not real
         #     wall-clock (JS-loop benches inflate 30-100x vs production
@@ -426,6 +463,14 @@ jobs:
         # Pinned to a full version (not the floating @v4) so the
         # instrumentation environment stays identical between the main
         # baseline and PR runs.
+        # The inner command is wrapped in tools/ci/with-nashua-lock.sh, the
+        # cross-repo flock mutex for this shared box (see that script's header).
+        # Taking the lock INSIDE the action's `run` — rather than in an earlier
+        # step — is deliberate on both counts: flock lives and dies with a
+        # process, so it cannot be held across separate workflow steps, and this
+        # way only the CPU-saturating bench fan-out is serialized, leaving the
+        # action's own setup and result upload free to overlap with a Playwright
+        # run on one of the other two repos.
         # Note: vitest 3's hard-coded 60s worker-RPC timer counts real
         # seconds while valgrind slows the process ~60x, so large suites
         # structurally trip "Timeout calling onTaskUpdate" AFTER their
@@ -436,7 +481,7 @@ jobs:
         uses: CodSpeedHQ/action@v4.18.2
         with:
           mode: simulation
-          run: yarn lerna run bench --parallel --stream ${{ steps.scope.outputs.flags }}
+          run: bash tools/ci/with-nashua-lock.sh yarn lerna run bench --parallel --stream ${{ steps.scope.outputs.flags }}
 
   codspeed-walltime:
     needs: [detect-changes, build]
@@ -464,7 +509,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          # Pinned for the same reason as the simulation job above: V8 changes
+          # between patch releases move the numbers, and walltime is if anything
+          # more sensitive than instruction counts. Keep this in step with the
+          # codspeed-bench pin so the two instruments stay comparable.
+          node-version: '22.23.1'
       - name: Download all built dists
         uses: actions/download-artifact@v4
         with:

--- a/docs/ci/self-hosted-runner.md
+++ b/docs/ci/self-hosted-runner.md
@@ -1,6 +1,6 @@
 # Self-hosted CodSpeed benchmark runner
 
-The `codspeed-bench` job in `.github/workflows/pr-checks.yml` runs on a
+The `codspeed-bench` job in `.github/workflows/bench.yml` runs on a
 **dedicated self-hosted runner** (`runs-on: [self-hosted, codspeed-bench, nashua]`)
 instead of GitHub's shared pool.
 
@@ -271,7 +271,7 @@ or SIGKILL, so there are no stale locks to clean up. If the lock is busy it logs
 the current holder (from `<lock>.info`) and waits up to `NASHUA_LOCK_WAIT`
 (default 5400s / 90 min) before failing the step.
 
-In `pr-checks.yml` the wrapper sits **inside** the CodSpeed action's `run:`:
+In `bench.yml` the wrapper sits **inside** the CodSpeed action's `run:`:
 
 ```yaml
 run: bash tools/ci/with-nashua-lock.sh yarn lerna run bench --parallel --stream …

--- a/docs/ci/self-hosted-runner.md
+++ b/docs/ci/self-hosted-runner.md
@@ -30,12 +30,29 @@ and the regression gate is trustworthy.
 
 ## Hardware hygiene (for stable numbers)
 
-- **Dedicate the box to this label.** Register it so it only picks up the
-  `codspeed-bench` label and runs **one job at a time** (the default). Do not
-  co-locate other CI or workloads on it — contention is noise.
-- Pin the CPU: disable turbo boost and, ideally, SMT/hyper-threading; set the
-  CPU governor to `performance`. A VM is fine if it has a pinned vCPU and is
-  otherwise idle.
+This runner hosts the **simulation** gate only, which changes what matters:
+
+- **Simulation is clock- and concurrency-independent.** Cachegrind counts
+  instructions on a *modeled* CPU cache, per process — so turbo boost, SMT,
+  and the CPU governor do **not** affect the numbers, and running benches in
+  parallel does not corrupt them (each valgrind process models its own cache).
+  You do **not** need the strict single-core isolation that wall-clock
+  benchmarking requires.
+- **Multiple cores are a throughput win.** valgrind runs ~60× slower than
+  native, so the job is CPU-bound; the workflow already fans out with
+  `lerna run bench --parallel`, which uses all available cores. More threads →
+  the job finishes faster, with identical instruction counts.
+- **Dedicate the box to this label** and let it run **one GitHub job at a
+  time** (the default). This is about not co-scheduling *other* jobs on the
+  box mid-run, not about intra-job parallelism — that stays on.
+- The only hard requirement for cross-run stability is a **fixed CPU model**
+  (don't migrate the box between different physical CPUs), since the modeled
+  cache is derived from it.
+
+> If the **walltime** job (`codspeed-macro`, `mode: walltime`) is ever moved
+> onto a self-hosted box, this advice inverts: wall-clock needs an isolated,
+> pinned core with turbo/SMT off and nothing else running. Keep walltime and
+> simulation on separate runners.
 
 ## Registering the runner
 

--- a/docs/ci/self-hosted-runner.md
+++ b/docs/ci/self-hosted-runner.md
@@ -21,10 +21,13 @@ and the regression gate is trustworthy.
 
 ## What the box must provide
 
-- **OS**: **Ubuntu 22.04 / 24.04 or Debian 11 / 12**, x86_64 or aarch64 — not
-  general "Linux x64" latitude. CodSpeed publishes its patched valgrind `.deb`
-  only for those releases, and the CodSpeed runner bails with "Unsupported system"
-  on anything else. nashua is Ubuntu 24.04 x86_64.
+- **OS**: **Ubuntu 22.04 / 24.04, or Debian 12**, x86_64 or aarch64 — not general
+  "Linux x64" latitude. The CodSpeed runner maps the distro onto one of two deb
+  builds and bails with "Unsupported system" otherwise; at v4.18.2 the guard is
+  literally `version == "22.04" || version == "12"`, so **Debian 11 and Ubuntu
+  20.04 are out**, even though CodSpeed's CLI docs list them as supported (that
+  claim is about the CLI generally, not the valgrind deb targets). Debian 12 maps
+  to the `ubuntu-22.04` asset. nashua is Ubuntu 24.04 x86_64.
 - **CodSpeed's own valgrind build** — see [Valgrind](#valgrind-codspeeds-own-build).
   Do *not* install the distro or snap valgrind.
 - **`libc6-dbg`** (glibc debug symbols) — the CodSpeed runner checks for this

--- a/docs/ci/self-hosted-runner.md
+++ b/docs/ci/self-hosted-runner.md
@@ -40,8 +40,10 @@ and the regression gate is trustworthy.
   version (`22.23.1`) rather than the `'22'` range the other jobs use — see
   [Hardware hygiene](#hardware-hygiene-for-stable-numbers) for why. It does not
   need to be pre-installed; the runner user only needs write access to the actions
-  tool cache. The box's own nvm-managed node is irrelevant, since setup-node
-  prepends its install to the job's `PATH`.
+  tool cache. **The box provides no node on `PATH` of its own**, so anything a
+  workflow needs *before* `setup-node` runs will not find one — provision tools
+  after that step, not before. (That is why the Corepack note below sits where it
+  does.)
 - **yarn is *not* required on the box** — and is in fact absent there, since the
   other two repos use pnpm. GitHub's hosted images preinstall yarn 1, which is
   what this workflow used to rely on implicitly. The bench job now provisions it
@@ -85,10 +87,8 @@ and installs it with apt, caching the result under `$HOME/.cache/codspeed-action
 install needs root**, and the CodSpeed runner checks for a non-interactive path
 before taking it: either it is already root, or `sudo -n true` succeeds.
 
-On nashua the GitHub Actions runner's service account deliberately has **no
-passwordless sudo** — that account executes PR-supplied code for a public repo on
-a box shared with two other repos' runners, so a standing root grant is not worth
-it. Valgrind is therefore **pre-installed by hand and held**, which makes the
+On nashua the GitHub Actions runner's service account has **no passwordless
+sudo**, by design. Valgrind is therefore **pre-installed by hand and held**, which makes the
 CodSpeed runner short-circuit: when a new-enough `.codspeed` valgrind *and*
 `libc6-dbg` are already present it never attempts to elevate.
 
@@ -286,13 +286,10 @@ bench run.
 
 ### Operational gotchas
 
-- **The lock files must be owned by `root`, mode 0666, unless every runner runs
-  as the same OS user.** Whichever repo's job runs first creates
-  `/var/tmp/nashua-playwright.lock` owned by that runner's user with mode 0644;
-  a runner under a different user then cannot open it read-write and the step
-  errors with `cannot open lock file`. Check the identities with
-  `grep -H '^User=' /etc/systemd/system/actions.runner.*.service` — that is the
-  identity that matters, not whoever ran `config.sh`.
+- **The lock files must be owned by `root`, mode 0666.** Left to itself, the
+  first job to run creates `/var/tmp/nashua-playwright.lock` owned by that
+  runner's own account with mode 0644, and every other runner then fails to open
+  it read-write with `cannot open lock file`.
 
   Mode alone is not sufficient. `/var/tmp` is world-writable and sticky, so
   `fs.protected_regular` (on by default; check with
@@ -316,9 +313,6 @@ bench run.
   ```
   If the files are deleted, whichever runner recreates them becomes their owner
   and the problem returns; recreate them as root.
-
-  A runner installed as root can open a lock file owned by anyone, so such a
-  runner locks out the others rather than itself.
 - **`/var/tmp`, not `/tmp`**, is deliberate: `/tmp` is frequently a tmpfs and is
   cleaned far more aggressively (systemd-tmpfiles defaults: 10 days for `/tmp`,
   30 for `/var/tmp`), so `/var/tmp` survives reboots and idle weeks.
@@ -337,8 +331,8 @@ bench run.
 
 1. Repo → **Settings → Actions → Runners → New self-hosted runner** → Linux/x64.
 2. Unpack it into its **own directory**, separate from the cornerstone3D and
-   OHIF runners already on the box (each runner needs its own `_work`), and run
-   it as the **same OS user** as those two — see the lock-ownership gotcha above.
+   OHIF runners already on the box (each runner needs its own `_work`). Each
+   runner runs under its **own dedicated OS account**, created ahead of step 4.
 3. Follow the download/configure steps GitHub shows. When configuring, add the
    label the workflow targets:
    `./config.sh --url https://github.com/cornerstonejs/codecs --token <token> --name "OHIF Ubuntu Server - Nashua" --labels codspeed-bench,nashua`
@@ -352,7 +346,8 @@ bench run.
    `Runner name:` in the **Set up job** log of every run and this repo is public,
    so pick a name you are happy publishing (the interactive default is the
    machine's hostname — which is logged as `Machine name:` either way).
-4. Install it as a service so it survives reboots (`./svc.sh install && ./svc.sh start`).
+4. Install it as a service so it survives reboots, naming the account it runs as
+   (`./svc.sh install <account> && ./svc.sh start`).
    Each runner directory installs its own service; the unit is named
    `actions.runner.cornerstonejs-codecs.<runner-name>`.
 5. Confirm it shows **Idle** in Settings → Actions → Runners, and as the runner

--- a/docs/ci/self-hosted-runner.md
+++ b/docs/ci/self-hosted-runner.md
@@ -1,8 +1,13 @@
 # Self-hosted CodSpeed benchmark runner
 
 The `codspeed-bench` job in `.github/workflows/pr-checks.yml` runs on a
-**dedicated self-hosted runner** (`runs-on: [self-hosted, codspeed-bench]`)
+**dedicated self-hosted runner** (`runs-on: [self-hosted, codspeed-bench, nashua]`)
 instead of GitHub's shared pool.
+
+The runner is dedicated to this repo, but the **machine is not**: the box
+("nashua") also hosts runners for `cornerstonejs/cornerstone3D` and
+`OHIF/Viewers`. A filesystem mutex keeps the three repos' heavy jobs from
+colliding — see [Sharing the box](#sharing-the-box-the-nashua-flock-mutex).
 
 ## Why
 
@@ -16,17 +21,141 @@ and the regression gate is trustworthy.
 
 ## What the box must provide
 
-- **OS**: Linux x64.
-- **valgrind** installed and on `PATH` (`valgrind --version`). CodSpeed's
-  simulation runs the benches under valgrind; the box must have it (the job
-  does not install it).
-- **git** and outbound network (to reach github.com and codspeed.io).
-- Node is provisioned per-job by `actions/setup-node@v4` (node 22), so it does
-  not need to be pre-installed — but the runner user must be able to write to
-  the actions tool cache.
+- **OS**: **Ubuntu 22.04 / 24.04 or Debian 11 / 12**, x86_64 or aarch64 — not
+  general "Linux x64" latitude. CodSpeed publishes its patched valgrind `.deb`
+  only for those releases, and the CodSpeed runner bails with "Unsupported system"
+  on anything else. nashua is Ubuntu 24.04 x86_64.
+- **CodSpeed's own valgrind build** — see [Valgrind](#valgrind-codspeeds-own-build).
+  Do *not* install the distro or snap valgrind.
+- **`libc6-dbg`** (glibc debug symbols) — the CodSpeed runner checks for this
+  package explicitly alongside valgrind. Already present on nashua.
+- **git** and outbound network — github.com, codspeed.io, and the
+  valgrind-codspeed release assets.
+- **flock** (from `util-linux`, present on any stock Linux) — `tools/ci/with-nashua-lock.sh`
+  needs it for the shared-box mutex below.
+- Node is provisioned per-job by `actions/setup-node@v4`, pinned to an **exact**
+  version (`22.23.1`) rather than the `'22'` range the other jobs use — see
+  [Hardware hygiene](#hardware-hygiene-for-stable-numbers) for why. It does not
+  need to be pre-installed; the runner user only needs write access to the actions
+  tool cache. The box's own nvm-managed node is irrelevant, since setup-node
+  prepends its install to the job's `PATH`.
+- **yarn is *not* required on the box** — and is in fact absent there, since the
+  other two repos use pnpm. GitHub's hosted images preinstall yarn 1, which is
+  what this workflow used to rely on implicitly. The bench job now provisions it
+  per-job with Corepack instead:
+  ```yaml
+  corepack enable yarn
+  corepack prepare yarn@1.22.22 --activate
+  ```
+  Corepack is bundled with node 22 and fetches over Node's own https. That is
+  deliberate rather than incidental: `npm i -g yarn` is unreliable here because
+  the npm reachable from the GitHub runner's *bundled* node on this box is
+  corrupted (`Cannot find module '../lib/cli.js'`) — the same wall OHIF's workflow
+  hit, which is why it provisions pnpm through Corepack too. Note node 25
+  unbundles Corepack, so a major node bump means revisiting that step.
 - A C toolchain is **not** needed here: this job only downloads prebuilt
   `dist-*` artifacts and runs `vitest bench`; the wasm is compiled in the
   `build` job on GitHub-hosted runners.
+
+## Valgrind (CodSpeed's own build)
+
+> **"Runner" is overloaded — this section means the CodSpeed one.** Three distinct
+> things go by that name here: the **GitHub Actions runner** (the `Runner.Listener`
+> agent registered to one repo — three of them on this box, installed with
+> `config.sh`/`svc.sh`); the **CodSpeed runner** (`codspeed-runner`, the binary
+> `CodSpeedHQ/action` downloads into the job, which drives valgrind and uploads
+> results); and CodSpeed's hosted **macro runners** (`runs-on: codspeed-macro`,
+> used by the separate `codspeed-walltime` job). Everything below about detecting
+> and installing valgrind is the **CodSpeed runner**.
+
+CodSpeed does **not** use the distro's valgrind. Simulation mode runs on a
+patched Callgrind, and the CodSpeed runner rejects any `valgrind --version` string
+that does not contain `.codspeed` ("not a CodSpeed build"). So `apt install
+valgrind` is pointless — it would just be replaced — and the **snap is actively
+wrong**, because its confinement blocks instrumenting host binaries.
+
+Left to itself, the action installs the right build: it downloads
+`valgrind_<version>_ubuntu-<release>_<arch>.deb` from
+[CodSpeedHQ/valgrind-codspeed](https://github.com/CodSpeedHQ/valgrind-codspeed/releases)
+and installs it with apt, caching the result under `$HOME/.cache/codspeed-action`
+(`cache-instruments` defaults to `true`, so it is a one-time cost per box). **That
+install needs root**, and the CodSpeed runner checks for a non-interactive path
+before taking it: either it is already root, or `sudo -n true` succeeds.
+
+On nashua the GitHub Actions runner's service account deliberately has **no
+passwordless sudo** — that account executes PR-supplied code for a public repo on
+a box shared with two other repos' runners, so a standing root grant is not worth
+it. Valgrind is therefore **pre-installed by hand and held**, which makes the
+CodSpeed runner short-circuit: when a new-enough `.codspeed` valgrind *and*
+`libc6-dbg` are already present it never attempts to elevate.
+
+### Which version
+
+The version is pinned by the action version, so read it off the chain rather than
+guessing:
+
+1. `CodSpeedHQ/action@vX.Y.Z` → the `.codspeed-runner-version` file in that tag
+   (which CodSpeed runner version the action downloads).
+2. That tag of `CodSpeedHQ/runner` → `src/binary_pins.rs` →
+   `VALGRIND_CODSPEED_VERSION` and `VALGRIND_CODSPEED_ITERATION`.
+3. The deb is `<version>-0codspeed<iteration>`. A *higher* iteration also passes
+   the CodSpeed runner's check; an older one does not.
+
+For the currently pinned `CodSpeedHQ/action@v4.18.2` (CodSpeed runner 4.18.2) that
+is **3.26.0 iteration 4**:
+
+```bash
+curl -fL -o /tmp/valgrind-codspeed.deb \
+  https://github.com/CodSpeedHQ/valgrind-codspeed/releases/download/3.26.0-0codspeed4/valgrind_3.26.0-0codspeed4_ubuntu-24.04_amd64.deb
+sudo apt-get install -y /tmp/valgrind-codspeed.deb
+sudo apt-mark hold valgrind
+
+valgrind --version                       # want: valgrind-3.26.0.codspeed4
+dpkg -s libc6-dbg | grep -m1 Status      # want: install ok installed
+```
+
+Those two commands mirror the CodSpeed runner's own gate, which is why they are the
+ones to trust — see `src/executor/valgrind/setup.rs` in
+[CodSpeedHQ/runner](https://github.com/CodSpeedHQ/runner/blob/v4.18.2/src/executor/valgrind/setup.rs)
+at the pinned tag. `is_valgrind_installed()` requires both:
+
+- `get_valgrind_status()` → runs `which valgrind`, then `valgrind --version`, then
+  rejects any string without `.codspeed` and any `(version, iteration)` below the
+  pin;
+- `apt::is_package_installed("libc6-dbg")` → literally `dpkg -s libc6-dbg`.
+
+When both pass, `apt::install_cached` skips the install step entirely ("check if
+already installed — if yes, skip everything"), and that is precisely what keeps
+sudo out of the picture.
+
+### Why it is held
+
+Ubuntu's own valgrind is `1:3.22.0-0ubuntu2` — note the **epoch `1:`**, against
+CodSpeed's un-epoched `3.26.0-0codspeed4`. The epoch dominates dpkg's version
+ordering, so apt considers the *older* distro build an upgrade: a routine
+`apt upgrade`, or an unattended security update, would silently swap out the
+CodSpeed build. The next bench run would then see "not a CodSpeed build", try to
+reinstall it, find no passwordless sudo, and fail. `apt-mark hold valgrind`
+prevents that — confirm with `apt-mark showhold`, or `dpkg -s valgrind` showing
+`Status: hold ok installed`. The cost is that valgrind stops getting distro
+security updates, which is the right trade for a tool that only ever instruments
+our own benchmarks.
+
+### When bumping `CodSpeedHQ/action`
+
+A new action version can raise the valgrind pin, which makes a box visit a
+**prerequisite of the bump** — otherwise the bench step fails during setup
+(loudly, not silently):
+
+```bash
+sudo apt-mark unhold valgrind
+sudo apt-get install -y /tmp/<new-valgrind-codspeed>.deb
+sudo apt-mark hold valgrind
+```
+
+Do it on the box *before* merging the bump, and expect the new valgrind to shift
+instruction counts — treat it like any other environment change and let one
+`main` run re-seed the baseline.
 
 ## Hardware hygiene (for stable numbers)
 
@@ -42,33 +171,187 @@ This runner hosts the **simulation** gate only, which changes what matters:
   native, so the job is CPU-bound; the workflow already fans out with
   `lerna run bench --parallel`, which uses all available cores. More threads →
   the job finishes faster, with identical instruction counts.
-- **Dedicate the box to this label** and let it run **one GitHub job at a
-  time** (the default). This is about not co-scheduling *other* jobs on the
-  box mid-run, not about intra-job parallelism — that stays on.
+- **Keep it to one heavy job on the box at a time.** Each runner on nashua
+  takes one GitHub job at a time (the default), but the three runners are
+  independent processes and nothing stops all three from starting at once. The
+  flock mutex below is what actually enforces one-at-a-time; it is about not
+  co-scheduling *other repos'* heavy jobs mid-run, not about intra-job
+  parallelism — that stays on.
 - The only hard requirement for cross-run stability is a **fixed CPU model**
   (don't migrate the box between different physical CPUs), since the modeled
   cache is derived from it.
+- **Pin node exactly, never by range.** Given a range like `'22'`, setup-node uses
+  any satisfying version already in the tool cache *without consulting the
+  network*. On a self-hosted box that cache persists, so the bench silently
+  freezes on the first 22.x it ever saw and then jumps whenever the box is
+  rebuilt or the cache is cleared — and V8 changes between patch releases move
+  instruction counts. Both codspeed jobs pin `22.23.1`, the version the current
+  baseline was measured on. Changing it is a deliberate re-seed event, exactly
+  like a glibc or valgrind bump.
+- **Don't casually `apt upgrade` the box.** glibc is the sharpest example:
+  different glibc builds dispatch different code paths, so a bump shifts
+  instruction counts much as a different CPU would — that is the subject of
+  CodSpeed's own [write-up](https://codspeed.io/blog/unrelated-benchmark-regression)
+  on unrelated benchmark regressions. Patch deliberately rather than
+  incidentally, then let one `main` run re-seed the baseline. Keeping valgrind
+  held (above) also keeps *it* out of any such upgrade.
 
 > If the **walltime** job (`codspeed-macro`, `mode: walltime`) is ever moved
 > onto a self-hosted box, this advice inverts: wall-clock needs an isolated,
 > pinned core with turbo/SMT off and nothing else running. Keep walltime and
 > simulation on separate runners.
 
+## Sharing the box: the nashua flock mutex
+
+Three repos have a self-hosted runner on nashua. A runner registers to exactly
+one repository, so each repo needs its own runner process:
+
+| Repo | Runner label | Heavy job |
+| --- | --- | --- |
+| `cornerstonejs/codecs` (this repo) | `codspeed-bench` + `nashua` | CodSpeed simulation benches under valgrind |
+| `cornerstonejs/cornerstone3D` | `nashua` | Playwright (`playwright.yml`, `ohif-downstream.yml`) |
+| `OHIF/Viewers` | `nashua` | Playwright (`playwright.yml`) |
+
+Labels only select runners *within* a repo, so the `nashua` label on the other
+two and `codspeed-bench` here never interact — and GitHub's `concurrency:` is
+scoped per repository, so it cannot coordinate across repos either (let alone
+across the two orgs). The only thing tying the three together is a lock file on
+the box's filesystem, taken with `flock`:
+
+```
+/var/tmp/nashua-playwright.lock
+```
+
+Each repo carries its own copy of the wrapper script, because a script cannot be
+shared across separate repositories:
+
+| Repo | Wrapper |
+| --- | --- |
+| codecs | `tools/ci/with-nashua-lock.sh` |
+| cornerstone3D | `scripts/ci/with-nashua-lock.sh` |
+| OHIF/Viewers | `.scripts/ci/with-nashua-lock.sh` |
+
+The paths differ; **the lock path must not**. All three default to the same
+`NASHUA_LOCK_FILE`, and a mismatch silently disables the mutex rather than
+failing loudly. Renaming it means changing all three repos in lockstep.
+
+### Why the name says "playwright"
+
+Historical: Playwright was the mutex's first and, until codecs joined, only
+user. It is really "the nashua heavy-job mutex". The misleading name is kept
+because the path is the coordination mechanism itself — a rename that lands in
+one repo before the others leaves the box unprotected. Read
+`nashua-playwright.lock` as "nashua is busy", not "Playwright is running".
+
+### Why the bench job takes it (Playwright is not the reason here)
+
+- The bench job **saturates every core**: valgrind runs ~60× slower than native
+  and `lerna run bench --parallel` fans out across all of them. Playwright
+  suites in the other two repos measure wall-clock behaviour and flake badly
+  under that load; their browsers plus valgrind together also strain box RAM.
+- In the other direction, a **starved bench job gets noisy**: vitest 3's
+  hard-coded 60s worker-RPC timer counts *real* seconds while valgrind stretches
+  the process, so contention makes those structural "Timeout calling
+  onTaskUpdate" failures more likely.
+- What is **not** at risk is CodSpeed simulation's numbers themselves.
+  Cachegrind models a CPU cache per process, so instruction counts do not shift
+  because other work is running (see [Hardware hygiene](#hardware-hygiene-for-stable-numbers)).
+  This lock buys predictable job duration, fewer flakes and memory headroom —
+  not measurement stability. Fixed *hardware* is what buys that.
+
+### How it is wired
+
+`with-nashua-lock.sh` opens the lock file on fd 9, `flock`s it, then `exec`s the
+wrapped command, which inherits the fd. The lock therefore lives exactly as long
+as the command — released automatically on success, failure, job cancel, timeout
+or SIGKILL, so there are no stale locks to clean up. If the lock is busy it logs
+the current holder (from `<lock>.info`) and waits up to `NASHUA_LOCK_WAIT`
+(default 5400s / 90 min) before failing the step.
+
+In `pr-checks.yml` the wrapper sits **inside** the CodSpeed action's `run:`:
+
+```yaml
+run: bash tools/ci/with-nashua-lock.sh yarn lerna run bench --parallel --stream …
+```
+
+Two reasons it goes there rather than in an earlier step: a flock is held by a
+process, and each workflow step is a separate process, so it *cannot* span
+steps; and this scopes the mutex to the CPU-hungry bench fan-out, letting the
+action's setup and result upload overlap with another repo's run. The job's
+`timeout-minutes: 180` covers the worst case of a 90 min wait followed by a full
+bench run.
+
+### Operational gotchas
+
+- **All three runners should run as the same OS user.** Whichever repo's job
+  runs first *creates* `/var/tmp/nashua-playwright.lock`, owned by that user with
+  mode 0644; a second runner under a different user then fails to open it
+  read-write and the step errors with `cannot open lock file`. Check all three
+  with `grep -H '^User=' /etc/systemd/system/actions.runner.*.service` (that is
+  the identity that matters — not whoever ran `config.sh`). Note the asymmetry:
+  root can open a lock file owned by anyone, so a runner accidentally installed
+  as root locks out the others rather than itself.
+
+  If the users must differ, make the files world-writable. When they do not exist
+  yet:
+  ```bash
+  sudo install -m 0666 /dev/null /var/tmp/nashua-playwright.lock
+  sudo install -m 0666 /dev/null /var/tmp/nashua-playwright.lock.info
+  ```
+  When they already exist, `chmod` instead — and only while the box is idle.
+  `chmod` keeps the inode, whereas replacing the file would leave an in-flight
+  job holding a lock on the old inode while the next job locks the new one, so
+  both would run:
+  ```bash
+  sudo chmod 0666 /var/tmp/nashua-playwright.lock /var/tmp/nashua-playwright.lock.info
+  ```
+- **`/var/tmp`, not `/tmp`**, is deliberate: `/tmp` is frequently a tmpfs and is
+  cleaned far more aggressively (systemd-tmpfiles defaults: 10 days for `/tmp`,
+  30 for `/var/tmp`), so `/var/tmp` survives reboots and idle weeks.
+- **Never set `PrivateTmp=yes` on the runner services.** It gives each unit a
+  private `/tmp` *and* `/var/tmp`, which would hand every runner its own lock
+  file — the mutex would then do nothing, silently. The runner's own
+  `svc.sh`-generated unit does not set it; keep it that way.
+- **Waiting is invisible in the job's step list.** A job blocked on the mutex
+  looks like a long-running "Run CodSpeed benchmarks" step; the log line
+  `nashua box busy — held by: <repo>#<run-id>` is the tell.
+- **Local runs don't need the wrapper** — call `yarn lerna run bench` directly.
+  It does work off the box if you want it (`NASHUA_LOCK_FILE=/tmp/my.lock bash
+  tools/ci/with-nashua-lock.sh …`).
+
 ## Registering the runner
 
 1. Repo → **Settings → Actions → Runners → New self-hosted runner** → Linux/x64.
-2. Follow the download/configure steps GitHub shows. When configuring, add the
-   custom label so the workflow can target it:
-   `./config.sh --url https://github.com/cornerstonejs/codecs --token <token> --labels codspeed-bench`
-   (the `self-hosted`, `Linux`, `X64` labels are added automatically).
-3. Install it as a service so it survives reboots (`./svc.sh install && ./svc.sh start`).
-4. Confirm it shows **Idle** in Settings → Actions → Runners.
+2. Unpack it into its **own directory**, separate from the cornerstone3D and
+   OHIF runners already on the box (each runner needs its own `_work`), and run
+   it as the **same OS user** as those two — see the lock-ownership gotcha above.
+3. Follow the download/configure steps GitHub shows. When configuring, add the
+   label the workflow targets:
+   `./config.sh --url https://github.com/cornerstonejs/codecs --token <token> --name "OHIF Ubuntu Server - Nashua" --labels codspeed-bench,nashua`
+   (`self-hosted`, `Linux`, `X64` are added automatically). That matches the
+   runner currently registered for this repo, and **both** custom labels are
+   needed: the job asks for `runs-on: [self-hosted, codspeed-bench, nashua]`, so a
+   runner missing either one is never picked and the job queues forever. `nashua`
+   also records which box this is; labels never cross repos, so it cannot collide
+   with the identically-labelled cornerstone3D and OHIF runners. Note the runner
+   name is **not private**: it is printed as
+   `Runner name:` in the **Set up job** log of every run and this repo is public,
+   so pick a name you are happy publishing (the interactive default is the
+   machine's hostname — which is logged as `Machine name:` either way).
+4. Install it as a service so it survives reboots (`./svc.sh install && ./svc.sh start`).
+   Each runner directory installs its own service; the unit is named
+   `actions.runner.cornerstonejs-codecs.<runner-name>`.
+5. Confirm it shows **Idle** in Settings → Actions → Runners, and as the runner
+   user: `valgrind --version` prints a `.codspeed` build (see
+   [Valgrind](#valgrind-codspeeds-own-build)) and `flock --version` works.
+   `sudo -n true` is *expected to fail* here — that is precisely why valgrind is
+   pre-installed rather than left to the action.
 
 ## Cutover order (important)
 
-1. **Register and start the runner first** (above). If the workflow merges
-   before a runner with the `codspeed-bench` label is online, the
-   `codspeed-bench` job queues indefinitely.
+1. **Register and start the runner first** (above). If the workflow merges before
+   a runner carrying **both** the `codspeed-bench` and `nashua` labels is online,
+   the `codspeed-bench` job queues indefinitely.
 2. Merge this change to `main`.
 3. The push to `main` runs `codspeed-bench` on the new runner and **re-seeds
    the CodSpeed baseline on the fixed hardware**. Until that main run
@@ -80,3 +363,8 @@ This runner hosts the **simulation** gate only, which changes what matters:
 
 Revert `runs-on` back to `ubuntu-24.04` on the `codspeed-bench` job. The next
 `main` run re-seeds the baseline on GitHub-hosted hardware again.
+
+The lock wrapper can stay in place through a rollback — on an ephemeral
+GitHub-hosted VM it just acquires an uncontended lock and `exec`s the command —
+but it is dead weight there, so drop it from the `run:` (and drop
+`timeout-minutes: 180` back to something tighter) if the revert is permanent.

--- a/docs/ci/self-hosted-runner.md
+++ b/docs/ci/self-hosted-runner.md
@@ -286,28 +286,39 @@ bench run.
 
 ### Operational gotchas
 
-- **All three runners should run as the same OS user.** Whichever repo's job
-  runs first *creates* `/var/tmp/nashua-playwright.lock`, owned by that user with
-  mode 0644; a second runner under a different user then fails to open it
-  read-write and the step errors with `cannot open lock file`. Check all three
-  with `grep -H '^User=' /etc/systemd/system/actions.runner.*.service` (that is
-  the identity that matters — not whoever ran `config.sh`). Note the asymmetry:
-  root can open a lock file owned by anyone, so a runner accidentally installed
-  as root locks out the others rather than itself.
+- **The lock files must be owned by `root`, mode 0666, unless every runner runs
+  as the same OS user.** Whichever repo's job runs first creates
+  `/var/tmp/nashua-playwright.lock` owned by that runner's user with mode 0644;
+  a runner under a different user then cannot open it read-write and the step
+  errors with `cannot open lock file`. Check the identities with
+  `grep -H '^User=' /etc/systemd/system/actions.runner.*.service` — that is the
+  identity that matters, not whoever ran `config.sh`.
 
-  If the users must differ, make the files world-writable. When they do not exist
-  yet:
+  Mode alone is not sufficient. `/var/tmp` is world-writable and sticky, so
+  `fs.protected_regular` (on by default; check with
+  `sysctl fs.protected_regular`) permits opening an existing regular file there
+  for writing only if the opener owns the file or the file is owned by the
+  directory's owner. `/var/tmp` is owned by root, so the lock files must be too;
+  otherwise the open fails with `Permission denied` regardless of mode.
+
+  Create them as root:
   ```bash
   sudo install -m 0666 /dev/null /var/tmp/nashua-playwright.lock
   sudo install -m 0666 /dev/null /var/tmp/nashua-playwright.lock.info
   ```
-  When they already exist, `chmod` instead — and only while the box is idle.
-  `chmod` keeps the inode, whereas replacing the file would leave an in-flight
-  job holding a lock on the old inode while the next job locks the new one, so
-  both would run:
+  If they already exist with the wrong owner, fix owner and mode in place, while
+  the box is idle. `chown`/`chmod` keep the inode; replacing the file would leave
+  an in-flight job holding a lock on the old inode while the next job locks the
+  new one, so both would run:
   ```bash
+  sudo chown root:root /var/tmp/nashua-playwright.lock /var/tmp/nashua-playwright.lock.info
   sudo chmod 0666 /var/tmp/nashua-playwright.lock /var/tmp/nashua-playwright.lock.info
   ```
+  If the files are deleted, whichever runner recreates them becomes their owner
+  and the problem returns; recreate them as root.
+
+  A runner installed as root can open a lock file owned by anyone, so such a
+  runner locks out the others rather than itself.
 - **`/var/tmp`, not `/tmp`**, is deliberate: `/tmp` is frequently a tmpfs and is
   cleaned far more aggressively (systemd-tmpfiles defaults: 10 days for `/tmp`,
   30 for `/var/tmp`), so `/var/tmp` survives reboots and idle weeks.

--- a/docs/ci/self-hosted-runner.md
+++ b/docs/ci/self-hosted-runner.md
@@ -1,0 +1,65 @@
+# Self-hosted CodSpeed benchmark runner
+
+The `codspeed-bench` job in `.github/workflows/pr-checks.yml` runs on a
+**dedicated self-hosted runner** (`runs-on: [self-hosted, codspeed-bench]`)
+instead of GitHub's shared pool.
+
+## Why
+
+CodSpeed simulation mode (Cachegrind) derives its modeled CPU cache from the
+**physical** runner CPU. GitHub's shared runners randomly assign different
+hardware (Intel Xeon 8370C vs AMD EPYC 7763), so identical source produces
+different instruction counts run-to-run and CodSpeed flags "Different runtime
+environments detected". A single fixed box removes that variable: every run —
+baseline and PR — is measured on the same hardware, so Simulation is stable
+and the regression gate is trustworthy.
+
+## What the box must provide
+
+- **OS**: Linux x64.
+- **valgrind** installed and on `PATH` (`valgrind --version`). CodSpeed's
+  simulation runs the benches under valgrind; the box must have it (the job
+  does not install it).
+- **git** and outbound network (to reach github.com and codspeed.io).
+- Node is provisioned per-job by `actions/setup-node@v4` (node 22), so it does
+  not need to be pre-installed — but the runner user must be able to write to
+  the actions tool cache.
+- A C toolchain is **not** needed here: this job only downloads prebuilt
+  `dist-*` artifacts and runs `vitest bench`; the wasm is compiled in the
+  `build` job on GitHub-hosted runners.
+
+## Hardware hygiene (for stable numbers)
+
+- **Dedicate the box to this label.** Register it so it only picks up the
+  `codspeed-bench` label and runs **one job at a time** (the default). Do not
+  co-locate other CI or workloads on it — contention is noise.
+- Pin the CPU: disable turbo boost and, ideally, SMT/hyper-threading; set the
+  CPU governor to `performance`. A VM is fine if it has a pinned vCPU and is
+  otherwise idle.
+
+## Registering the runner
+
+1. Repo → **Settings → Actions → Runners → New self-hosted runner** → Linux/x64.
+2. Follow the download/configure steps GitHub shows. When configuring, add the
+   custom label so the workflow can target it:
+   `./config.sh --url https://github.com/cornerstonejs/codecs --token <token> --labels codspeed-bench`
+   (the `self-hosted`, `Linux`, `X64` labels are added automatically).
+3. Install it as a service so it survives reboots (`./svc.sh install && ./svc.sh start`).
+4. Confirm it shows **Idle** in Settings → Actions → Runners.
+
+## Cutover order (important)
+
+1. **Register and start the runner first** (above). If the workflow merges
+   before a runner with the `codspeed-bench` label is online, the
+   `codspeed-bench` job queues indefinitely.
+2. Merge this change to `main`.
+3. The push to `main` runs `codspeed-bench` on the new runner and **re-seeds
+   the CodSpeed baseline on the fixed hardware**. Until that main run
+   completes, the first PR comparisons will show a one-time environment shift
+   (old shared-runner baseline vs new fixed-hardware head) — that is expected
+   and self-resolves after the baseline is re-seeded.
+
+## Rollback
+
+Revert `runs-on` back to `ubuntu-24.04` on the `codspeed-bench` job. The next
+`main` run re-seeds the baseline on GitHub-hosted hardware again.

--- a/tools/ci/with-nashua-lock.sh
+++ b/tools/ci/with-nashua-lock.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Run a command while holding the shared "nashua" box mutex.
+#
+# The nashua machine hosts THREE self-hosted GitHub runners — one per repo, since
+# a runner registers to exactly one repository:
+#
+#   cornerstonejs/codecs        label: codspeed-bench   (this repo — CodSpeed bench)
+#   cornerstonejs/cornerstone3D label: nashua           (Playwright + OHIF downstream)
+#   OHIF/Viewers                label: nashua           (Playwright)
+#
+# Each runner takes one job at a time, so left alone the box would run up to
+# three heavy jobs simultaneously. GitHub's `concurrency:` is scoped per
+# repository and cannot coordinate across repos (let alone across the two orgs),
+# so the mutex lives on the box's filesystem instead.
+#
+# Why codecs takes this lock — NOT for Playwright:
+#   - The bench job saturates every core: valgrind runs ~60x slower than native
+#     and `lerna run bench --parallel` fans out across all of them. The other two
+#     repos measure Playwright wall-clock behaviour, which flakes badly under
+#     that load (and their browsers plus valgrind together strain box RAM).
+#   - In the other direction, a starved bench job trips vitest 3's hard-coded 60s
+#     worker-RPC timer, which counts REAL seconds while valgrind stretches the
+#     process — so contention turns a slow job into a noisy one.
+#   - CodSpeed *simulation* numbers themselves are contention-immune (Cachegrind
+#     models a CPU cache per process, so instruction counts do not shift when
+#     other work runs alongside). This lock protects job duration, flakiness and
+#     memory headroom — not count stability. See docs/ci/self-hosted-runner.md.
+#
+# The lock file is named ...-playwright.lock for historical reasons: Playwright
+# was its first and, until now, only user. It is really "the nashua heavy-job
+# mutex". Do NOT rename it here alone — the path is the only thing tying the
+# three repos together, and a mismatch silently disables the mutex instead of
+# failing loudly. Renaming means changing all three copies in lockstep.
+#
+# This script can NOT be shared across the repos (separate repositories), so each
+# carries its own copy at its own path — codecs: tools/ci/with-nashua-lock.sh,
+# cornerstone3D: scripts/ci/with-nashua-lock.sh, OHIF: .scripts/ci/with-nashua-lock.sh.
+# Only the NASHUA_LOCK_FILE default below has to agree.
+#
+# flock holds the lock via fd 9 and it releases automatically when the wrapped
+# command exits — including on job cancel / timeout / SIGKILL — so there are no
+# stale locks to clean up.
+#
+# Usage: bash tools/ci/with-nashua-lock.sh <command> [args...]
+
+# Strict mode: -e abort on any unhandled command failure, -u treat use of an
+# unset variable as an error, -o pipefail make a pipeline fail if ANY stage
+# fails (not just the last). Catches mistakes early instead of pressing on.
+set -euo pipefail
+
+LOCK="${NASHUA_LOCK_FILE:-/var/tmp/nashua-playwright.lock}"   # MUST match cornerstone3D's and OHIF's copies
+LOCK_WAIT="${NASHUA_LOCK_WAIT:-5400}"                          # max seconds to wait
+
+# Guard: a command to wrap is required. With no arguments there is nothing to
+# run, so print usage and exit instead of silently grabbing and releasing the
+# lock for no reason (which would mask a mis-wired workflow step).
+if [ "$#" -eq 0 ]; then
+  echo "usage: $0 <command> [args...]" >&2
+  exit 2
+fi
+
+# Open the lock file on fd 9 (read-write, create if missing, never truncate).
+# A failure here is usually ownership, not absence: whichever repo's job runs
+# first creates the file, so all three runners must run as the same OS user (or
+# the file must be pre-created world-writable). See docs/ci/self-hosted-runner.md.
+exec 9<>"$LOCK" || { echo "::error::cannot open lock file $LOCK (check it is writable by the runner user)"; exit 1; }
+
+# Try instantly; if busy, report who holds it, then block up to LOCK_WAIT.
+if ! flock -n 9; then
+  echo "nashua box busy — held by: $(cat "${LOCK}.info" 2>/dev/null || echo unknown). Waiting up to ${LOCK_WAIT}s…"
+  if ! flock -w "$LOCK_WAIT" 9; then
+    echo "::error::Timed out after ${LOCK_WAIT}s waiting for the nashua box lock"
+    exit 1
+  fi
+fi
+
+# Record the current holder for other jobs' "held by" message (best-effort).
+echo "${GITHUB_REPOSITORY:-local}#${GITHUB_RUN_ID:-0} @ $(date -u +%FT%TZ 2>/dev/null || true)" > "${LOCK}.info" 2>/dev/null || true
+echo "✅ Acquired nashua box lock ($LOCK); running: $*"
+
+# Replace the shell with the command. fd 9 is inherited (not close-on-exec), so
+# the lock is held for the whole command and released when it exits.
+exec "$@"


### PR DESCRIPTION
## Why

CodSpeed simulation mode derives its modeled CPU cache from the **physical** runner CPU. GitHub's shared runners randomly assign Intel Xeon 8370C vs AMD EPYC 7763, so identical source shifts instruction counts run-to-run and CodSpeed flags "Different runtime environments detected" — the noise behind the phantom regressions we've been triaging. Pinning the OS wasn't enough; the CPU model is the remaining variable.

## Change

- `codspeed-bench` (the blocking simulation gate) now runs on `runs-on: [self-hosted, codspeed-bench]` instead of `ubuntu-24.04`. One fixed box → every baseline and PR run on identical hardware → Simulation is stable.
- Adds `docs/ci/self-hosted-runner.md`: box requirements (valgrind, node 22, isolated/pinned CPU), how to register the runner, and the cutover order.
- Only the simulation gate moves; `build`/`test`/`dist-size`/`browser-smoke` stay on GitHub-hosted runners. (`codspeed-walltime` already targets `codspeed-macro` behind a repo variable — unchanged.)

## ⚠️ Do not merge until the runner is online

Cutover order matters:
1. **Register + start** the self-hosted runner with the `codspeed-bench` label FIRST (see the doc). If this merges before a runner with that label exists, the `codspeed-bench` job queues indefinitely.
2. Merge this.
3. The `main` push re-seeds the CodSpeed baseline on the fixed hardware. The first PR comparisons after cutover show a one-time environment shift (old shared-runner baseline vs new fixed head) — expected, self-resolves once the baseline is re-seeded.

Rollback: revert `runs-on` to `ubuntu-24.04`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated performance benchmarking for pull requests, pushes to `main`, and manual runs.
  * Benchmarks target affected packages when possible and restore matching build artifacts.
  * Added safeguards to skip or report unavailable benchmark builds.

* **Chores**
  * Improved reliability with pinned tool versions and coordinated execution.
  * Moved simulation benchmarks to a dedicated self-hosted runner.

* **Documentation**
  * Added setup, operating, coordination, and rollback guidance for the self-hosted benchmark runner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->