### PR TITLE
build: generate CSP-safe Embind adapters

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -118,6 +118,7 @@ jobs:
             "babel.config.json"
             "lerna.json"
             "tools/ci/"
+            "tools/csp/"
             "tools/dist-size/"
             "tools/browser-smoke/"
             "tools/fixture-verification/"

--- a/packages/charls/CMakeLists.txt
+++ b/packages/charls/CMakeLists.txt
@@ -36,6 +36,11 @@ add_subdirectory(extern/charls EXCLUDE_FROM_ALL)
 
 # add the js wrapper
 if(EMSCRIPTEN)
+  # Generate Embind adapters at build time so consumers do not need CSP unsafe-eval.
+  add_link_options(
+    "-sDYNAMIC_EXECUTION=0"
+    "-sEMBIND_AOT=1"
+  )
   add_subdirectory(src)
 endif()
 

--- a/packages/charls/build.sh
+++ b/packages/charls/build.sh
@@ -15,3 +15,4 @@ cp ./build/src/charlswasm_decode.wasm ./dist
 cp ./build/src/charlsjs_decode.js ./dist
 cp ./build/src/charlsjs_decode.js.mem ./dist
 (npm run test:benchmark)
+node ../../tools/csp/check-generated-js.js ./dist

--- a/packages/charls/build.sh
+++ b/packages/charls/build.sh
@@ -14,5 +14,7 @@ cp ./build/src/charlswasm_decode.js ./dist
 cp ./build/src/charlswasm_decode.wasm ./dist
 cp ./build/src/charlsjs_decode.js ./dist
 cp ./build/src/charlsjs_decode.js.mem ./dist
-(npm run test:benchmark)
-node ../../tools/csp/check-generated-js.js ./dist
+test_status=0
+(npm run test:benchmark) || test_status=$?
+node ../../tools/csp/check-generated-js.js ./dist || exit $?
+exit "${test_status}"

--- a/packages/libjpeg-turbo-12bit/CMakeLists.txt
+++ b/packages/libjpeg-turbo-12bit/CMakeLists.txt
@@ -39,6 +39,11 @@ add_subdirectory(extern/libjpeg-turbo EXCLUDE_FROM_ALL)
 
 # add the js wrapper
 if(EMSCRIPTEN)
+  # Generate Embind adapters at build time so consumers do not need CSP unsafe-eval.
+  add_link_options(
+    "-sDYNAMIC_EXECUTION=0"
+    "-sEMBIND_AOT=1"
+  )
   add_subdirectory(src)
 endif()
 

--- a/packages/libjpeg-turbo-12bit/build.sh
+++ b/packages/libjpeg-turbo-12bit/build.sh
@@ -22,5 +22,6 @@ echo "~~~ BUILD:"
 (cd build && dir)
 echo "~~~ DIST:"
 (cd dist && dir)
+node ../../tools/csp/check-generated-js.js ./dist
 # echo "~~~ TEST:"
 # (cd test/node; npm run test)

--- a/packages/libjpeg-turbo-8bit/CMakeLists.txt
+++ b/packages/libjpeg-turbo-8bit/CMakeLists.txt
@@ -39,6 +39,11 @@ add_subdirectory(extern/libjpeg-turbo EXCLUDE_FROM_ALL)
 
 # add the js wrapper
 if(EMSCRIPTEN)
+  # Generate Embind adapters at build time so consumers do not need CSP unsafe-eval.
+  add_link_options(
+    "-sDYNAMIC_EXECUTION=0"
+    "-sEMBIND_AOT=1"
+  )
   add_subdirectory(src)
 endif()
 

--- a/packages/libjpeg-turbo-8bit/build.sh
+++ b/packages/libjpeg-turbo-8bit/build.sh
@@ -30,5 +30,7 @@ echo "~~~ BUILD:"
 echo "~~~ DIST:"
 (cd dist && dir)
 echo "~~~ TEST:"
-(cd test/node; npm run test)
-node ../../tools/csp/check-generated-js.js ./dist
+test_status=0
+(cd test/node; npm run test) || test_status=$?
+node ../../tools/csp/check-generated-js.js ./dist || exit $?
+exit "${test_status}"

--- a/packages/libjpeg-turbo-8bit/build.sh
+++ b/packages/libjpeg-turbo-8bit/build.sh
@@ -31,3 +31,4 @@ echo "~~~ DIST:"
 (cd dist && dir)
 echo "~~~ TEST:"
 (cd test/node; npm run test)
+node ../../tools/csp/check-generated-js.js ./dist

--- a/packages/openjpeg/CMakeLists.txt
+++ b/packages/openjpeg/CMakeLists.txt
@@ -40,6 +40,11 @@ add_subdirectory(extern/openjpeg EXCLUDE_FROM_ALL)
 
 # add the js wrapper
 if(EMSCRIPTEN)
+  # Generate Embind adapters at build time so consumers do not need CSP unsafe-eval.
+  add_link_options(
+    "-sDYNAMIC_EXECUTION=0"
+    "-sEMBIND_AOT=1"
+  )
   add_subdirectory(src)
 endif()
 

--- a/packages/openjpeg/build.sh
+++ b/packages/openjpeg/build.sh
@@ -33,5 +33,7 @@ echo "~~~ BUILD:"
 echo "~~~ DIST:"
 (cd dist && dir)
 echo "~~~ TEST:"
-(cd test/node; npm run test)
-node ../../tools/csp/check-generated-js.js ./dist
+test_status=0
+(cd test/node; npm run test) || test_status=$?
+node ../../tools/csp/check-generated-js.js ./dist || exit $?
+exit "${test_status}"

--- a/packages/openjpeg/build.sh
+++ b/packages/openjpeg/build.sh
@@ -34,3 +34,4 @@ echo "~~~ DIST:"
 (cd dist && dir)
 echo "~~~ TEST:"
 (cd test/node; npm run test)
+node ../../tools/csp/check-generated-js.js ./dist

--- a/packages/openjphjs/CMakeLists.txt
+++ b/packages/openjphjs/CMakeLists.txt
@@ -27,6 +27,11 @@ add_subdirectory(extern/openjph EXCLUDE_FROM_ALL)
 
 # add the js wrapper
 if(EMSCRIPTEN)
+  # Generate Embind adapters at build time so consumers do not need CSP unsafe-eval.
+  add_link_options(
+    "-sDYNAMIC_EXECUTION=0"
+    "-sEMBIND_AOT=1"
+  )
   add_subdirectory(src)
 endif()
 

--- a/packages/openjphjs/build.sh
+++ b/packages/openjphjs/build.sh
@@ -8,3 +8,4 @@ cp ./build/src/openjphjs.js ./dist
 cp ./build/src/openjphjs.wasm ./dist
 # disable tests for now since CI doesn't like to run with SIMD
 # (cd test/node; npm run test)
+node ../../tools/csp/check-generated-js.js ./dist

--- a/packages/openjphjs/build.sh
+++ b/packages/openjphjs/build.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -e
+
 mkdir -p build
 mkdir -p dist
 (cd build && CXXFLAGS=-msimd128 emcmake cmake -DCMAKE_BUILD_TYPE=Debug ..)

--- a/tools/browser-smoke/run.js
+++ b/tools/browser-smoke/run.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // Browser smoke-decode: loads every wasm/asm.js build variant of every
-// codec in headless Chromium, decodes its reference fixture IN THE PAGE,
-// and compares the SHA-256 of the decoded pixels against the RAW reference.
+// codec in headless Chromium. Active decoders process a reference fixture
+// IN THE PAGE and compare its SHA-256 against the RAW reference.
 //
 // This is the coverage node tests cannot give: emscripten glue differences
 // that only manifest in browsers (wasm URL resolution/locateFile, fetch vs
@@ -21,17 +21,25 @@ const { chromium } = require("playwright-core");
 const repoRoot = path.resolve(__dirname, "../..");
 
 // [package, dist module, decoder class, encoded fixture, reference raw]
-// Every entry decodes CT1/jpeg400 and must hash-match its committed RAW.
+// Active decoders hash-match CT1/jpeg400; disabled decoders initialize only.
 const VARIANTS = [
   ["charls", "charlsjs.js", "JpegLSDecoder", "charls/test/fixtures/CT1.JLS", "charls/test/fixtures/CT1.RAW"],
+  ["charls", "charlsjs_decode.js", "JpegLSDecoder", "charls/test/fixtures/CT1.JLS", "charls/test/fixtures/CT1.RAW"],
   ["charls", "charlswasm.js", "JpegLSDecoder", "charls/test/fixtures/CT1.JLS", "charls/test/fixtures/CT1.RAW"],
   ["charls", "charlswasm_decode.js", "JpegLSDecoder", "charls/test/fixtures/CT1.JLS", "charls/test/fixtures/CT1.RAW"],
   ["openjpeg", "openjpegjs.js", "J2KDecoder", "openjpeg/test/fixtures/j2k/CT1.j2k", "openjpeg/test/fixtures/raw/CT1.RAW"],
+  ["openjpeg", "openjpegjs_decode.js", "J2KDecoder", "openjpeg/test/fixtures/j2k/CT1.j2k", "openjpeg/test/fixtures/raw/CT1.RAW"],
   ["openjpeg", "openjpegwasm.js", "J2KDecoder", "openjpeg/test/fixtures/j2k/CT1.j2k", "openjpeg/test/fixtures/raw/CT1.RAW"],
   ["openjpeg", "openjpegwasm_decode.js", "J2KDecoder", "openjpeg/test/fixtures/j2k/CT1.j2k", "openjpeg/test/fixtures/raw/CT1.RAW"],
   ["openjphjs", "openjphjs.js", "HTJ2KDecoder", "openjphjs/test/fixtures/j2c/CT1.j2c", "openjphjs/test/fixtures/raw/CT1.RAW"],
   ["libjpeg-turbo-8bit", "libjpegturbojs.js", "JPEGDecoder", "libjpeg-turbo-8bit/test/fixtures/jpeg/jpeg400jfif.jpg", "libjpeg-turbo-8bit/test/fixtures/raw/jpeg400jfif.raw"],
+  ["libjpeg-turbo-8bit", "libjpegturbojs_decode.js", "JPEGDecoder", "libjpeg-turbo-8bit/test/fixtures/jpeg/jpeg400jfif.jpg", "libjpeg-turbo-8bit/test/fixtures/raw/jpeg400jfif.raw"],
   ["libjpeg-turbo-8bit", "libjpegturbowasm.js", "JPEGDecoder", "libjpeg-turbo-8bit/test/fixtures/jpeg/jpeg400jfif.jpg", "libjpeg-turbo-8bit/test/fixtures/raw/jpeg400jfif.raw"],
+  ["libjpeg-turbo-8bit", "libjpegturbowasm_decode.js", "JPEGDecoder", "libjpeg-turbo-8bit/test/fixtures/jpeg/jpeg400jfif.jpg", "libjpeg-turbo-8bit/test/fixtures/raw/jpeg400jfif.raw"],
+  // The 12-bit decode path is disabled, but module initialization still
+  // exercises its generated JavaScript and WebAssembly under the CSP.
+  ["libjpeg-turbo-12bit", "libjpegturbo12js.js"],
+  ["libjpeg-turbo-12bit", "libjpegturbo12wasm.js"],
 ];
 
 const MIME = {
@@ -51,7 +59,11 @@ function startServer() {
       res.end("not found");
       return;
     }
-    res.writeHead(200, { "Content-Type": MIME[path.extname(filePath)] ?? "application/octet-stream" });
+    res.writeHead(200, {
+      "Content-Type": MIME[path.extname(filePath)] ?? "application/octet-stream",
+      // Permit WebAssembly compilation without permitting eval() or Function().
+      "Content-Security-Policy": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'",
+    });
     fs.createReadStream(filePath).pipe(res);
   });
   return new Promise((resolve) => server.listen(0, "127.0.0.1", () => resolve(server)));
@@ -72,6 +84,8 @@ const PAGE_FN = async ({ distUrl, decoderClass, fixtureUrl }) => {
   if (typeof factory !== "function") throw new Error("no module factory global found");
   const codec = await factory();
   delete globalThis.Module;
+
+  if (!decoderClass) return null;
 
   const fixture = new Uint8Array(await (await fetch(fixtureUrl)).arrayBuffer());
   const decoder = new codec[decoderClass]();
@@ -100,7 +114,9 @@ const PAGE_FN = async ({ distUrl, decoderClass, fixtureUrl }) => {
       if (process.env.CI) results.push([`${pkg}/${dist}`, "FAIL: dist missing in CI"]);
       continue;
     }
-    const expected = crypto.createHash("sha256").update(fs.readFileSync(path.join(repoRoot, "packages", raw))).digest("hex");
+    const expected = raw
+      ? crypto.createHash("sha256").update(fs.readFileSync(path.join(repoRoot, "packages", raw))).digest("hex")
+      : null;
     const page = await browser.newPage();
     const pageErrors = [];
     page.on("pageerror", (e) => pageErrors.push(e.message));
@@ -111,7 +127,8 @@ const PAGE_FN = async ({ distUrl, decoderClass, fixtureUrl }) => {
         decoderClass,
         fixtureUrl: `http://127.0.0.1:${port}/packages/${fixture}`,
       });
-      results.push([`${pkg}/${dist}`, actual === expected ? "PASS" : `FAIL: hash mismatch (${actual.slice(0, 12)}… != ${expected.slice(0, 12)}…)`]);
+      const success = decoderClass ? "PASS" : "PASS (module initialized)";
+      results.push([`${pkg}/${dist}`, actual === expected ? success : `FAIL: hash mismatch (${actual.slice(0, 12)}… != ${expected.slice(0, 12)}…)`]);
     } catch (e) {
       results.push([`${pkg}/${dist}`, `FAIL: ${e.message}${pageErrors.length ? " | page: " + pageErrors.join("; ") : ""}`]);
     } finally {
@@ -125,6 +142,6 @@ const PAGE_FN = async ({ distUrl, decoderClass, fixtureUrl }) => {
   const width = Math.max(...results.map(([n]) => n.length));
   for (const [name, r] of results) console.log(name.padEnd(width + 2) + r);
   const failures = results.filter(([, r]) => r.startsWith("FAIL")).length;
-  console.log(`\n${failures === 0 ? "PASS" : "FAIL"}: ${failures} browser decode failure(s)`);
+  console.log(`\n${failures === 0 ? "PASS" : "FAIL"}: ${failures} browser smoke failure(s)`);
   process.exit(failures ? 1 : 0);
 })();

--- a/tools/csp/check-generated-js.js
+++ b/tools/csp/check-generated-js.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const distDirectory = path.resolve(process.argv[2] ?? "");
+
+if (!process.argv[2] || !fs.existsSync(distDirectory)) {
+  console.error("Usage: node tools/csp/check-generated-js.js <dist-directory>");
+  process.exit(1);
+}
+
+const javascriptFiles = fs
+  .readdirSync(distDirectory)
+  .filter((fileName) => fileName.endsWith(".js"))
+  .sort();
+
+if (javascriptFiles.length === 0) {
+  console.error(`No generated JavaScript found in ${distDirectory}`);
+  process.exit(1);
+}
+
+const forbiddenDynamicCode = [
+  ["eval()", /\beval\s*\(/],
+  ["new Function()", /\bnew\s+Function\s*\(/],
+  ["Emscripten Function constructor", /\bnewFunc\s*\(\s*Function\s*,/],
+];
+
+const violations = [];
+
+for (const fileName of javascriptFiles) {
+  const source = fs.readFileSync(path.join(distDirectory, fileName), "utf8");
+
+  for (const [description, pattern] of forbiddenDynamicCode) {
+    if (pattern.test(source)) {
+      violations.push(`${fileName}: ${description}`);
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error("Generated codec JavaScript contains CSP-unsafe dynamic code:");
+  violations.forEach((violation) => console.error(`- ${violation}`));
+  process.exit(1);
+}
+
+console.log(`CSP-safe generated JavaScript: ${javascriptFiles.length} file(s) checked`);

--- a/tools/csp/check-generated-js.js
+++ b/tools/csp/check-generated-js.js
@@ -23,7 +23,7 @@ if (javascriptFiles.length === 0) {
 
 const forbiddenDynamicCode = [
   ["eval()", /\beval\s*\(/],
-  ["new Function()", /\bnew\s+Function\s*\(/],
+  ["Function constructor", /\b(?:new\s+)?Function\s*\(/],
   ["Emscripten Function constructor", /\bnewFunc\s*\(\s*Function\s*,/],
 ];
 

--- a/tools/csp/check-generated-js.test.js
+++ b/tools/csp/check-generated-js.test.js
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { spawnSync } from "node:child_process"
+
+const checkerPath = fileURLToPath(
+  new URL("./check-generated-js.js", import.meta.url)
+)
+const temporaryDirectories = []
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+function runChecker(source) {
+  const directory = mkdtempSync(join(tmpdir(), "codec-csp-check-"))
+  temporaryDirectories.push(directory)
+  writeFileSync(join(directory, "generated.js"), source)
+
+  return spawnSync(process.execPath, [checkerPath, directory], {
+    encoding: "utf8",
+  })
+}
+
+describe("generated JavaScript CSP checker", () => {
+  it.each([
+    ["eval()", 'eval("dynamic code")', "eval()"],
+    ["Function()", 'Function("return 1")', "Function constructor"],
+    ["new Function()", 'new Function("return 1")', "Function constructor"],
+    [
+      "Emscripten Function adapter",
+      'newFunc(Function, "arg", "return arg")',
+      "Emscripten Function constructor",
+    ],
+  ])("rejects %s", (_name, source, expectedViolation) => {
+    const result = runChecker(source)
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain(expectedViolation)
+  })
+
+  it("accepts generated JavaScript without dynamic code", () => {
+    const result = runChecker("const add = (left, right) => left + right")
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain("CSP-safe generated JavaScript: 1 file(s) checked")
+  })
+})

--- a/tools/csp/vitest.config.mjs
+++ b/tools/csp/vitest.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    name: "csp",
+    include: ["*.test.js"],
+  },
+})

--- a/tools/dist-size/baseline.json
+++ b/tools/dist-size/baseline.json
@@ -7,24 +7,24 @@
   },
   "charls": {
     "charlsjs.js": {
-      "raw": 537029,
-      "gzip": 108457
+      "raw": 537142,
+      "gzip": 108201
     },
     "charlsjs_decode.js": {
-      "raw": 340455,
-      "gzip": 77502
+      "raw": 340214,
+      "gzip": 77220
     },
     "charlswasm.js": {
-      "raw": 54139,
-      "gzip": 14501
+      "raw": 54252,
+      "gzip": 14248
     },
     "charlswasm.wasm": {
       "raw": 247884,
       "gzip": 66579
     },
     "charlswasm_decode.js": {
-      "raw": 54146,
-      "gzip": 14506
+      "raw": 53905,
+      "gzip": 14232
     },
     "charlswasm_decode.wasm": {
       "raw": 145306,
@@ -33,42 +33,42 @@
   },
   "libjpeg-turbo-12bit": {
     "libjpegturbo12js.js": {
-      "raw": 2554703,
-      "gzip": 267545
+      "raw": 2461618,
+      "gzip": 259496
     },
     "libjpegturbo12wasm.js": {
-      "raw": 113584,
-      "gzip": 29160
+      "raw": 112153,
+      "gzip": 28570
     },
     "libjpegturbo12wasm.wasm": {
-      "raw": 2238843,
-      "gzip": 760829
+      "raw": 1954242,
+      "gzip": 688878
     }
   },
   "libjpeg-turbo-8bit": {
     "libjpegturbojs.js": {
-      "raw": 838040,
-      "gzip": 160427
+      "raw": 837711,
+      "gzip": 160006
     },
     "libjpegturbojs_decode.js": {
-      "raw": 418778,
-      "gzip": 118564
+      "raw": 417854,
+      "gzip": 117868
     },
     "libjpegturbowasm.js": {
-      "raw": 57327,
-      "gzip": 15530
+      "raw": 57440,
+      "gzip": 15274
     },
     "libjpegturbowasm.wasm": {
-      "raw": 448955,
-      "gzip": 96494
+      "raw": 448728,
+      "gzip": 96385
     },
     "libjpegturbowasm_decode.js": {
-      "raw": 56836,
-      "gzip": 15491
+      "raw": 56350,
+      "gzip": 15191
     },
     "libjpegturbowasm_decode.wasm": {
-      "raw": 180512,
-      "gzip": 70074
+      "raw": 180287,
+      "gzip": 69946
     }
   },
   "little-endian": {
@@ -79,38 +79,38 @@
   },
   "openjpeg": {
     "openjpegjs.js": {
-      "raw": 754525,
-      "gzip": 199851
+      "raw": 753931,
+      "gzip": 199072
     },
     "openjpegjs_decode.js": {
-      "raw": 541739,
-      "gzip": 139864
+      "raw": 540905,
+      "gzip": 139321
     },
     "openjpegwasm.js": {
-      "raw": 56588,
-      "gzip": 15346
+      "raw": 57685,
+      "gzip": 15161
     },
     "openjpegwasm.wasm": {
-      "raw": 368511,
-      "gzip": 127471
+      "raw": 367561,
+      "gzip": 127108
     },
     "openjpegwasm_decode.js": {
-      "raw": 55920,
-      "gzip": 15236
+      "raw": 55759,
+      "gzip": 14970
     },
     "openjpegwasm_decode.wasm": {
-      "raw": 255857,
-      "gzip": 84237
+      "raw": 255484,
+      "gzip": 84026
     }
   },
   "openjphjs": {
     "openjphjs.js": {
-      "raw": 113863,
-      "gzip": 28916
+      "raw": 114126,
+      "gzip": 28495
     },
     "openjphjs.wasm": {
-      "raw": 2296745,
-      "gzip": 673433
+      "raw": 2295156,
+      "gzip": 672818
     }
   }
 }

--- a/vitest.workspace.mjs
+++ b/vitest.workspace.mjs
@@ -2,4 +2,5 @@ import { defineWorkspace } from "vitest/config"
 
 export default defineWorkspace([
   "packages/*/vitest.config.mjs",
+  "tools/csp/vitest.config.mjs",
 ])


### PR DESCRIPTION
## Why this belongs in the codec build

https://csp-evaluator.withgoogle.com/

<img width="1734" height="1698" alt="CleanShot 2026-08-13 at 09 31 19@2x" src="https://github.com/user-attachments/assets/f7a2e15b-6770-483b-ae87-152ee91f50da" />


In production, applications should normally keep `script-src 'unsafe-eval'` disabled. That keyword permits JavaScript string-to-code APIs such as `eval()` and `Function()` across the entire document. When an application needs to compile or instantiate WebAssembly, CSP provides the narrower `wasm-unsafe-eval` source expression, which allows WebAssembly execution without also enabling general JavaScript evaluation. A typical production policy can therefore allow the codecs with `script-src 'self' 'wasm-unsafe-eval'` while continuing to block `eval()` and `Function()`.

The current requirement for broad `unsafe-eval` does not come from decoding or from WebAssembly itself. It comes from Embind generating JavaScript invoker functions at runtime. A consuming application cannot remove that behavior through normal bundler or deployment configuration; it must either patch the published codec output or weaken the CSP for the whole application.

The correct boundary for the fix is therefore the codec build. Emscripten provides `DYNAMIC_EXECUTION=0` specifically to prevent generated `eval()` and `Function()` calls, and `EMBIND_AOT=1` generates the same Embind invokers at compile time so bindings retain their normal performance. The codec is still fetched and instantiated as WebAssembly in the usual way; only the JavaScript adapters move from runtime generation to build-time generation. This gives every consumer CSP-safe artifacts without an API change or a per-application workaround.

## Summary

- generate Embind adapters at build time for CharLS, libjpeg-turbo 8/12-bit, OpenJPEG, and OpenJPH
- disable dynamic JavaScript execution in the generated Emscripten glue
- fail codec builds if generated JavaScript contains `eval()` or `Function` construction
- exercise all generated variants in Chromium under a CSP that permits WebAssembly but not general unsafe evaluation

## Root cause

The generated Embind glue created adapters at runtime with the `Function` constructor. Applications using a strict Content Security Policy therefore needed `script-src 'unsafe-eval'`, even though the codecs only require WebAssembly compilation.

Building with `DYNAMIC_EXECUTION=0` and `EMBIND_AOT=1` generates those adapters ahead of time. Consumers can keep general unsafe evaluation disabled and allow WebAssembly with `wasm-unsafe-eval` where required.

## Impact

This does not change the codec API. Across the affected artifacts, the total shipped size decreases by 384,592 bytes raw (3.02%) and 86,948 bytes gzip (2.76%). The OpenJPEG Wasm loader grows by 1,097 bytes raw while shrinking by 185 bytes gzip; the size baseline records that intentional change.

## Validation

- built all five Embind codec packages with Emscripten 3.1.74
- scanned all 15 generated JavaScript artifacts for dynamic code construction
- passed Chromium CSP smoke coverage for all 15 variants; active codecs decode and hash-match their fixtures, while the disabled 12-bit path is initialization-only
- `yarn test`: 146 passed, 18 skipped
- distribution size gate: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Generated JavaScript is now checked for unsafe dynamic execution patterns, improving compatibility with stricter Content Security Policies.
  * WebAssembly builds use safer execution settings without enabling general-purpose dynamic code evaluation.

* **Reliability**
  * Build and test workflows now validate generated artifacts and preserve meaningful test failure statuses.
  * Browser smoke tests provide broader coverage for module initialization and decoding scenarios.

* **Maintenance**
  * Distribution size baselines and automated validation coverage have been updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->