### PR TITLE
docs: clarify package descriptions

### DIFF
--- a/packages/big-endian/README.md
+++ b/packages/big-endian/README.md
@@ -1,6 +1,6 @@
 # @cornerstonejs/codec-big-endian
 
-Pure-JS decoder for the DICOM Big-Endian transfer syntax
+Pure JavaScript decoder for the DICOM Big Endian transfer syntax
 (`1.2.840.10008.1.2.2`).
 
 Reinterprets `pixelData` as `Uint16Array` or `Int16Array` (based on

--- a/packages/charls/README.md
+++ b/packages/charls/README.md
@@ -1,5 +1,5 @@
 # charls-js
-JS/WebAssembly build of [CharLS](https://github.com/team-charls/charls)
+JavaScript/WebAssembly build of [CharLS](https://github.com/team-charls/charls).
 
 ## Try It Out!
 

--- a/packages/dicom-codec/README.md
+++ b/packages/dicom-codec/README.md
@@ -1,6 +1,6 @@
 # dicom-codec
 
-DICOM Codecs for JavaScript (browser and node support).
+DICOM codecs for JavaScript, with browser and Node.js support.
 
 # Features (v1.0.1)
 | codec name        	| transferSyntaxUID(s)                                         	| decode 	| encode 	| external codec 	| js/wasm based 	|

--- a/packages/libjpeg-turbo-12bit/README.md
+++ b/packages/libjpeg-turbo-12bit/README.md
@@ -1,6 +1,6 @@
 # libjpeg-turbojs (12-bit)
 
-JS/WASM Build of [libjpeg-turbo](https://github.com/libjpeg-turbo) with `WITH12BIT=ON`.
+JavaScript/WebAssembly build of [libjpeg-turbo](https://github.com/libjpeg-turbo) with `WITH12BIT=ON`.
 
 ## Try It Out
 

--- a/packages/libjpeg-turbo-8bit/README.md
+++ b/packages/libjpeg-turbo-8bit/README.md
@@ -1,6 +1,6 @@
 # libjpeg-turbojs
 
-JS/WASM Build of [libjpeg-turbo](https://github.com/libjpeg-turbo).
+JavaScript/WebAssembly build of [libjpeg-turbo](https://github.com/libjpeg-turbo).
 
 ## Try It Out
 

--- a/packages/little-endian/README.md
+++ b/packages/little-endian/README.md
@@ -1,6 +1,6 @@
 # @cornerstonejs/codec-little-endian
 
-Pure-JS decoder for DICOM Little-Endian transfer syntaxes
+Pure JavaScript decoder for DICOM Little Endian transfer syntaxes
 (`1.2.840.10008.1.2`, `1.2.840.10008.1.2.1`, `1.2.840.10008.1.2.1.99`).
 
 Takes a `pixelData` byte view and reinterprets it as `Uint8Array`, `Uint16Array`,

--- a/packages/openjpeg/README.md
+++ b/packages/openjpeg/README.md
@@ -2,7 +2,7 @@
 
 
 
-This library is a JavaScript port made possible by [emscripten](https://emscripten.org/) and [Chris Hafey](https://github.com/chafey). It is a JavaScript and WebAssembly build of [OpenJPEG](https://github.com/uclouvain/openjpeg).
+This JavaScript/WebAssembly build of [OpenJPEG](https://github.com/uclouvain/openjpeg) is made possible by [Emscripten](https://emscripten.org/) and [Chris Hafey](https://github.com/chafey).
 
 ## Table of Contents
 

--- a/packages/openjphjs/README.md
+++ b/packages/openjphjs/README.md
@@ -1,6 +1,6 @@
 # openjphjs - HTJ2K support
 
-JS/WebAssembly build of [OpenJPH](https://github.com/aous72/OpenJPH)
+JavaScript/WebAssembly build of [OpenJPH](https://github.com/aous72/OpenJPH).
 
 ## Try It Out!
 


### PR DESCRIPTION
## Why

The previous release attempt pushed its version commit and package tags before failing during GitHub release creation. Rerunning that original pipeline checked out the older commit, so `lerna publish from-package` could not see the bumped package versions.

This documentation-only change intentionally creates a fresh, non-skipped pipeline from the latest `main`. Markdown remains excluded from Lerna's changed-package calculation, so this does not introduce another version bump while allowing the existing unpublished versions to proceed through the publication step.

## What changed

- Clarified the opening package description in each of the eight package READMEs.
- Kept the diff to exactly one replacement line per README.

## Validation

- `git diff --check origin/main...HEAD`
- Confirmed each README has exactly one added and one removed line.
- `lerna changed` reports no changed packages, as expected for Markdown-only changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified package descriptions using consistent “JavaScript/WebAssembly” terminology.
  * Improved capitalization, punctuation, and wording across codec documentation.
  * Explicitly documented browser and Node.js support where applicable.
  * Updated OpenJPEG documentation to identify its Emscripten-based implementation and contributors.
  * Standardized “Pure JavaScript,” “Big Endian,” and “Little Endian” terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->